### PR TITLE
Improve HaversackEphemeralStrategy ergonomics

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tvOS tests
       run: xcodebuild test -scheme Haversack-Package -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'
     - name: Run watchOS tests
-      run: xcodebuild test -scheme Haversack-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 8 (41mm)'
+      run: xcodebuild test -scheme Haversack-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm)'
 
   SwiftLint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Added convenience methods for accessing mock data values on the `HaversackEphemeralStrategy`
+
 ## [1.3.0] - 2024-02-11
 ### Added
 - Added support for visionOS.

--- a/Sources/Haversack/HaversackStrategy.swift
+++ b/Sources/Haversack/HaversackStrategy.swift
@@ -202,7 +202,7 @@ open class HaversackStrategy {
     ///
     /// This should not be called directly but is used by ``Haversack/Haversack/exportItems(_:config:)`` to perform the actual exporting
     /// - Parameters:
-    ///   - item: The keys, certificates, or identities to export
+    ///   - items: The keys, certificates, or identities to export
     ///   - configuration: A configuration representing all the options that can be provided to `SecItemExport`
     /// - Returns: A `Data` representation of the keychain item
     open func exportItems(_ items: [any KeychainExportable], configuration: KeychainExportConfig) throws -> Data {
@@ -232,8 +232,9 @@ open class HaversackStrategy {
 
     /// Imports one or more keys, certificates, or identities and adds them to the keychain
     /// - Parameters:
-    ///   - item: The keys, certificates, or identities to import
+    ///   - items: The keys, certificates, or identities to import
     ///   - configuration: A configuration representing all the options that can be provided to `SecItemImport`
+    ///   - importKeychain: The keychain to import the items to
     /// - Returns: An array of all the keychain items imported
     open func importItems<EntityType: KeychainImportable>(_ items: Data, configuration: KeychainImportConfig<EntityType>, importKeychain: SecKeychain? = nil) throws -> [EntityType] {
         var inputFormat = configuration.inputFormat

--- a/Sources/Haversack/ImportExport/KeychainImportConfig.swift
+++ b/Sources/Haversack/ImportExport/KeychainImportConfig.swift
@@ -122,7 +122,6 @@ public struct KeychainImportConfig<T: KeychainImportable> {
     }
 
     /// Make any imported keys extractable. By default keys are not extractable after import
-    /// - Parameter extractable: Whether or not the keychain item can be exported from its keychain (Defaults to false)
     /// - Returns: A `KeychainImportConfig` struct
     public func extractable() throws -> Self where T: PrivateKeyImporting {
         // swiftlint:disable:next line_length

--- a/Sources/HaversackMock/HaversackEphemeralStrategy+mocking.swift
+++ b/Sources/HaversackMock/HaversackEphemeralStrategy+mocking.swift
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2023, Jamf
+
+import Haversack
+import Security
+import XCTest
+
+extension Haversack {
+    /// A convenience accessor that handles typecasting the `HaversackStrategy` to a `HaversackEphemeralStrategy`
+    /// via XCTest's `XCTUnwrap` function.
+    var ephemeralStrategy: HaversackEphemeralStrategy {
+        get throws {
+            try XCTUnwrap(configuration.strategy as? HaversackEphemeralStrategy)
+        }
+    }
+}
+
+// MARK: Mock data setters
+extension Haversack {
+    /// Mocks data for calls to `Haversack.first(where:)`
+    /// - Parameters:
+    ///   - query: The query to set a mock value for
+    ///   - mockValue: The mock value to set
+    public func setSearchFirstMock<T: KeychainQuerying>(where query: T, mockValue: T.Entity) throws {
+        let query = try makeSearchQuery(query, singleItem: true)
+        try ephemeralStrategy.setMock(mockValue, forQuery: query.query)
+    }
+
+    /// Retrieves the value for a call to `Haversack.first(where:)` from ``HaversackEphemeralStrategy/mockData``
+    /// - Parameter query: The query to retrieve a value for
+    /// - Returns: The value associated with `query` in ``HaversackEphemeralStrategy/mockData``
+    public func getSearchFirstMock<T: KeychainQuerying>(where query: T) throws -> T.Entity? {
+        let query = try makeSearchQuery(query, singleItem: true)
+        return try ephemeralStrategy.getMockDataValue(for: query.query)
+    }
+
+    /// Mocks data for calls to `Haversack.search(where:)`
+    /// - Parameters:
+    ///   - query: The query to set a mock value for
+    ///   - mockValue: The mock value to set
+    public func setSearchMock<T: KeychainQuerying>(where query: T, mockValue: [T.Entity]) throws {
+        let query = try makeSearchQuery(query, singleItem: false)
+        try ephemeralStrategy.setMock(mockValue, forQuery: query.query)
+    }
+
+    /// Retrieves the value for a call to `Haversack.search(where:)` from ``HaversackEphemeralStrategy/mockData``
+    /// - Parameter query: The query to retrieve a value for
+    /// - Returns: The value associated with `query` in ``HaversackEphemeralStrategy/mockData``
+    public func getSearchMock<T: KeychainQuerying>(where query: T) throws -> [T.Entity]? {
+        let query = try makeSearchQuery(query, singleItem: false)
+        return try ephemeralStrategy.getMockDataValue(for: query.query)
+    }
+
+    /// Mocks data for calls to `Haversack.save(_:itemSecurity:updateExisting:)`. This is useful when
+    /// you want to test the behavior of your code when the item being saved already exists in the keychain.
+    /// - Parameters:
+    ///   - item: The item being saved
+    ///   - itemSecurity: The security the item should have
+    ///   - mockValue: The mock value to set
+    public func setSaveMock<T: KeychainStorable>(item: T, itemSecurity: ItemSecurity = .standard, mockValue: Any) throws {
+        let query = try makeSaveQuery(item, itemSecurity: itemSecurity)
+        try ephemeralStrategy.setMock(mockValue, forQuery: query)
+    }
+
+    /// Retrieves the value for a call to `Haversack.save(_:itemSecurity:updateExisting:)` from ``HaversackEphemeralStrategy/mockData``
+    /// - Parameters:
+    ///   - item: The item being saved
+    ///   - itemSecurity: The security the item should have
+    /// - Returns: The value associated with `query` in ``HaversackEphemeralStrategy/mockData``
+    public func getSaveMock<T: KeychainStorable>(item: T, itemSecurity: ItemSecurity = .standard) throws -> Any? {
+        let query = try makeSaveQuery(item, itemSecurity: itemSecurity)
+        return try ephemeralStrategy.getMockDataValue(for: query)
+    }
+
+    /// Mocks data for calls to `Haversack.delete(_:treatNotFoundAsSuccess:)`
+    /// - Parameters:
+    ///   - item: The item to generate a delete query and set a mock value for
+    ///   - mockValue: The mock value to set
+    public func setDeleteMock<T: KeychainStorable>(item: T, mockValue: Any) throws {
+        let query = try makeDeleteQuery(item)
+        try ephemeralStrategy.setMock(mockValue, forQuery: query)
+    }
+
+    /// Retrieves the value for a call to `Haversack.delete(_:treatNotFoundAsSuccess:)` from ``HaversackEphemeralStrategy/mockData``
+    /// - Parameter item: The item to generate a delete query and set a mock value for
+    /// - Returns: The value associated with `query` in ``HaversackEphemeralStrategy/mockData``
+    public func getDeleteMock<T: KeychainStorable>(item: T) throws -> Any? {
+        let query = try makeDeleteQuery(item)
+        return try ephemeralStrategy.getMockDataValue(for: query)
+    }
+
+    /// Mocks data for calls to `Haversack.delete(where:treatNotFoundAsSuccess:)`
+    /// - Parameters:
+    ///   - query: The query to set a mock value for
+    ///   - mockValue: The mock value to set
+    public func setDeleteMock<T: KeychainQuerying>(where query: T, mockValue: Any) throws {
+        let query = try makeDeleteQuery(query)
+        try ephemeralStrategy.setMock(mockValue, forQuery: query.query)
+    }
+
+    /// Retrieves the value for a call to `Haversack.delete(where:treatNotFoundAsSuccess:)` from ``HaversackEphemeralStrategy/mockData``
+    /// - Parameter query: The query to retrieve a value for
+    /// - Returns: The value associated with `query` in ``HaversackEphemeralStrategy/mockData``
+    public func getDeleteMock<T: KeychainQuerying>(where query: T) throws -> Any? {
+        let query = try makeDeleteQuery(query)
+        return try ephemeralStrategy.getMockDataValue(for: query.query)
+    }
+
+    /// Mocks data for calls to `Haversack.generateKey(fromConfig:itemSecurity:)`
+    /// - Parameters:
+    ///   - config: The key generation configuration values that the query should include
+    ///   - itemSecurity: The item security the query should specify
+    ///   - mockValue: The mock value to set
+    public func setGenerateKeyMock(config: KeyGenerationConfig, itemSecurity: ItemSecurity = .standard, mockValue: SecKey) throws {
+        let query = try makeKeyGenerationQuery(fromConfig: config, itemSecurity: itemSecurity)
+        try ephemeralStrategy.setMock(mockValue, forQuery: query)
+    }
+
+    /// Retrieves the value for a call to `Haversack.generateKey(fromConfig:itemSecurity:)` from ``HaversackEphemeralStrategy/mockData``
+    /// - Parameters:
+    ///   - config: The key generation configuration values that the query should include
+    ///   - itemSecurity: The item security the query should specify
+    /// - Returns: The value associated with `query` in ``HaversackEphemeralStrategy/mockData``
+    public func getGenerateKeyMock(config: KeyGenerationConfig, itemSecurity: ItemSecurity = .standard) throws -> SecKey? {
+        let query = try makeKeyGenerationQuery(fromConfig: config, itemSecurity: itemSecurity)
+        return try ephemeralStrategy.getMockDataValue(for: query)
+    }
+}
+
+extension HaversackEphemeralStrategy {
+    /// Generates a ``mockData`` key for the query and sets the value of that key to `mockValue`
+    /// - Parameters:
+    ///   - mockValue: The value to mock
+    ///   - query: The query that the mock value is associated with
+    func setMock(_ mockValue: Any, forQuery query: SecurityFrameworkQuery) {
+        mockData[key(for: query)] = mockValue
+    }
+
+    /// Retrieves the ``mockData`` value for the provided query
+    ///
+    /// This overload is required because `Optional<Any>` can be typecast to `Any`.
+    /// This means that if the generic version of this function were called where `T == Any`,
+    /// it would always return a non-nil value of `Any` with the actual type of `Optional<Any>.none`.
+    /// - Parameter query: The query to retreive a value for
+    /// - Returns: The value
+    func getMockDataValue(for query: SecurityFrameworkQuery) -> Any? {
+        mockData[key(for: query)]
+    }
+
+    /// Retrieves and typecasts the ``mockData`` value for the provided query
+    /// - Parameter query: The query to retreive a value for
+    /// - Returns: The typecasted value
+    func getMockDataValue<T>(for query: SecurityFrameworkQuery) -> T? {
+        getMockDataValue(for: query) as? T
+    }
+}

--- a/Sources/HaversackMock/HaversackEphemeralStrategy.swift
+++ b/Sources/HaversackMock/HaversackEphemeralStrategy.swift
@@ -7,6 +7,9 @@ import Haversack
 /// A strategy which uses a simple dictionary to search, store, and delete data instead of hitting an actual keychain.
 ///
 /// The keys of the ``mockData`` dictionary are calculated from the queries that are sent through Haversack.
+/// 
+/// You can also use either the untyped ``subscript(_:)-7weqp`` or the typed ``subscript(_:)-6jjzx``
+/// accessors to avoid having to hold onto the calculated keys.
 open class HaversackEphemeralStrategy: HaversackStrategy {
     /// The dictionary that is used for storage of keychain items
     ///
@@ -37,6 +40,25 @@ open class HaversackEphemeralStrategy: HaversackStrategy {
 
     /// If the strategy has any problems it will throw `NSError` with this domain.
     public static let errorDomain = "haversack.unit_testing.mock"
+
+    /// Untyped access to ``mockData`` values via keychain queries instead of `String`s
+    /// - Parameter query: The keychain query to read/write to
+    /// - Returns: The ``mockData`` value for the `query`
+    public subscript(_ query: any KeychainQuerying) -> Any? {
+        get {
+            mockData[key(for: query.query)]
+        }
+        set {
+            mockData[key(for: query.query)] = newValue
+        }
+    }
+
+    /// Typed access to ``mockData`` values via keychain queries instead of `String`s
+    /// - Parameter query: The keychain query to read the value for
+    /// - Returns: The ``mockData`` value for the `query`
+    public subscript<T>(_ query: any KeychainQuerying) -> T? {
+        self[query] as? T
+    }
 
     /// Looks through the ``mockData`` dictionary for an entry matching the query.
     /// - Parameter querying: An instance of a type that conforms to the `KeychainQuerying` protocol.

--- a/Tests/HaversackTests/EphemeralStrategyTests.swift
+++ b/Tests/HaversackTests/EphemeralStrategyTests.swift
@@ -64,4 +64,33 @@ final class EphemeralStrategyTests: XCTestCase {
         XCTAssertNotNil(mock.certificateImportConfiguration)
     }
     #endif
+
+    func testUntypedSubscript() throws {
+        // Given
+        let mock = HaversackEphemeralStrategy()
+        let query = GenericPasswordQuery()
+        let mockValue = "test"
+
+        // When
+        mock[query] = mockValue
+        let storedAny = mock[query]
+
+        // Then
+        let storedString = try XCTUnwrap(storedAny as? String)
+        XCTAssertEqual(storedString, mockValue)
+    }
+
+    func testTypedSubscript() {
+        // Given
+        let mock = HaversackEphemeralStrategy()
+        let query = GenericPasswordQuery()
+        let mockValue = "test"
+
+        // When
+        mock[query] = mockValue
+        let storedString: String? = mock[query]
+
+        // Then
+        XCTAssertEqual(storedString, mockValue)
+    }
 }

--- a/Tests/HaversackTests/EphemeralStrategyTests.swift
+++ b/Tests/HaversackTests/EphemeralStrategyTests.swift
@@ -6,23 +6,28 @@ import Haversack
 import HaversackMock
 
 final class EphemeralStrategyTests: XCTestCase {
-    func testInternetPWSearchReferenceMock() throws {
-        // given
-        let mock = HaversackEphemeralStrategy()
-        let expectedEntity = InternetPasswordEntity()
-        expectedEntity.protocol = .appleTalk
-        mock.mockData["acctlukeclassinetm_Limitm_Lir_Refsrvrstas"] = expectedEntity
-        let config = HaversackConfiguration(strategy: mock)
-        let haversack = Haversack(configuration: config)
+    var ephemeralStrategy: HaversackEphemeralStrategy!
+    var haversack: Haversack!
 
+    override func setUp() {
+        ephemeralStrategy = HaversackEphemeralStrategy()
+        haversack = Haversack(configuration: .init(strategy: ephemeralStrategy))
+    }
+
+    func testInternetPWSearchReferenceMock() throws {
+        // Given
         let pwQuery = InternetPasswordQuery(server: "stash")
             .matching(account: "luke")
             .returning(.reference)
 
-        // when
+        let expectedEntity = InternetPasswordEntity()
+        expectedEntity.protocol = .appleTalk
+        try haversack.setSearchFirstMock(where: pwQuery, mockValue: expectedEntity)
+
+        // When
         let password = try haversack.first(where: pwQuery)
 
-        // then
+        // Then
         XCTAssertNotNil(password)
         XCTAssertEqual(password.protocol, .appleTalk)
     }
@@ -30,15 +35,13 @@ final class EphemeralStrategyTests: XCTestCase {
     func testGenericPWSearchReferenceMock() throws {
         // given
         let testService = "unit.test"
-        let mock = HaversackEphemeralStrategy()
-        let expectedEntity = GenericPasswordEntity()
-        expectedEntity.service = testService
-        mock.mockData["classgenpm_Limitm_Lir_Refsvceunit"] = expectedEntity
-        let config = HaversackConfiguration(strategy: mock)
-        let haversack = Haversack(configuration: config)
 
         let pwQuery = GenericPasswordQuery(service: testService)
             .returning(.reference)
+
+        let expectedEntity = GenericPasswordEntity()
+        expectedEntity.service = testService
+        try haversack.setSearchFirstMock(where: pwQuery, mockValue: expectedEntity)
 
         // when
         let password = try haversack.first(where: pwQuery)
@@ -51,46 +54,130 @@ final class EphemeralStrategyTests: XCTestCase {
     #if os(macOS)
     func testImportItemsIncorrectMockEntities() throws {
         // Given
-        let mock = HaversackEphemeralStrategy()
-        mock.mockImportedEntities = [ KeyEntity() ]
+        ephemeralStrategy.mockImportedEntities = [ KeyEntity() ]
 
-        let haversack = Haversack(configuration: HaversackConfiguration(strategy: mock))
         let importConfig = KeychainImportConfig<CertificateEntity>()
 
         // When
         XCTAssertThrowsError(try haversack.importItems(Data(), config: importConfig))
 
         // Then
-        XCTAssertNotNil(mock.certificateImportConfiguration)
+        XCTAssertNotNil(ephemeralStrategy.certificateImportConfiguration)
     }
     #endif
 
-    func testUntypedSubscript() throws {
+    // MARK: Mocking tests
+
+    func testSetSearchFirstMock() throws {
         // Given
-        let mock = HaversackEphemeralStrategy()
-        let query = GenericPasswordQuery()
-        let mockValue = "test"
+        let testService = "unit.test"
+        let pwQuery = GenericPasswordQuery(service: testService)
+            .returning(.reference)
+
+        let expectedEntity = GenericPasswordEntity()
+        expectedEntity.service = testService
+        try haversack.setSearchFirstMock(where: pwQuery, mockValue: expectedEntity)
 
         // When
-        mock[query] = mockValue
-        let storedAny = mock[query]
+        let password = try haversack.first(where: pwQuery)
 
-        // Then
-        let storedString = try XCTUnwrap(storedAny as? String)
-        XCTAssertEqual(storedString, mockValue)
+        // Then no error should be thrown
+
+        // And the returned value should match the data that was set
+        XCTAssertNotNil(password)
+        XCTAssertEqual(password.service, testService)
     }
 
-    func testTypedSubscript() {
+    func testSetSearchMock() throws {
         // Given
-        let mock = HaversackEphemeralStrategy()
-        let query = GenericPasswordQuery()
-        let mockValue = "test"
+        let testService = "unit.test"
+        let pwQuery = GenericPasswordQuery(service: testService)
+            .returning(.reference)
+
+        let expectedEntity = GenericPasswordEntity()
+        expectedEntity.service = testService
+        try haversack.setSearchMock(where: pwQuery, mockValue: [expectedEntity])
 
         // When
-        mock[query] = mockValue
-        let storedString: String? = mock[query]
+        let passwords = try haversack.search(where: pwQuery)
 
-        // Then
-        XCTAssertEqual(storedString, mockValue)
+        // Then no error should be thrown
+
+        // And the returned value should match the data that was set
+        let password = try XCTUnwrap(passwords.first)
+        XCTAssertEqual(password.service, testService)
+    }
+
+    func testSetSaveMock() throws {
+        // Given
+        let mockEntity = GenericPasswordEntity()
+        let testService = "unit.test"
+        mockEntity.service = testService
+
+        try haversack.setSaveMock(item: mockEntity, itemSecurity: .standard, mockValue: mockEntity)
+
+        do {
+            // When
+            try haversack.save(mockEntity, itemSecurity: .standard, updateExisting: false)
+        } catch let error as HaversackError {
+            // Then attempting to save a value with updateExisting=false should throw
+            XCTAssertEqual(error, HaversackError.keychainError(errSecDuplicateItem))
+        }
+    }
+
+    func testSetDeleteWhereMock() throws {
+        // Given
+        let pwQuery = GenericPasswordQuery()
+            .returning(.reference)
+
+        try haversack.setDeleteMock(where: pwQuery, mockValue: "Any value")
+
+        // When
+        try haversack.delete(where: pwQuery, treatNotFoundAsSuccess: false)
+
+        // Then no error should be thrown
+
+        // And the value should have been deleted
+        XCTAssertNil(try haversack.getDeleteMock(where: pwQuery))
+    }
+
+    func testSetDeleteItemMock() throws {
+        // Given
+        let entity = GenericPasswordEntity()
+        try haversack.setDeleteMock(item: entity, mockValue: "Any value")
+
+        // When
+        try haversack.delete(entity, treatNotFoundAsSuccess: false)
+
+        // Then no error should be thrown
+
+        // And the value should have been deleted
+        XCTAssertNil(try haversack.getDeleteMock(item: entity))
+    }
+
+    func testSetGenerateKeyMock() throws {
+        func loadKey() throws -> SecKey {
+            let data = try Data(contentsOf: getURLForTestResource(named: "key.bsafe"))
+            let config = try KeychainImportConfig<KeyEntity>()
+                .inputFormat(.formatBSAFE)
+                .returnEntitiesWithoutSaving()
+
+            let importedEntities = try Haversack().importItems(data, config: config)
+            return try XCTUnwrap(importedEntities.first?.reference)
+        }
+
+        // Given
+        let testKey = try loadKey()
+        let keyGenerationConfig = KeyGenerationConfig(algorithm: .RSA, keySize: 2048)
+        try haversack.setGenerateKeyMock(config: keyGenerationConfig, mockValue: testKey)
+
+        // When
+        let key = try haversack.generateKey(fromConfig: keyGenerationConfig, itemSecurity: .standard)
+
+        // Then no error should be thrown
+
+        // And the value in `mockData` should be unchanged
+        let mockDataValue = try haversack.getGenerateKeyMock(config: keyGenerationConfig)
+        XCTAssertEqual(mockDataValue, key)
     }
 }

--- a/Tests/HaversackTests/EphemeralStrategyTests.swift
+++ b/Tests/HaversackTests/EphemeralStrategyTests.swift
@@ -155,6 +155,7 @@ final class EphemeralStrategyTests: XCTestCase {
         XCTAssertNil(try haversack.getDeleteMock(item: entity))
     }
 
+    #if os(macOS)
     func testSetGenerateKeyMock() throws {
         func loadKey() throws -> SecKey {
             let data = try Data(contentsOf: getURLForTestResource(named: "key.bsafe"))
@@ -180,4 +181,5 @@ final class EphemeralStrategyTests: XCTestCase {
         let mockDataValue = try haversack.getGenerateKeyMock(config: keyGenerationConfig)
         XCTAssertEqual(mockDataValue, key)
     }
+    #endif
 }


### PR DESCRIPTION
Having recently written some unit tests using the ephemeral strategy, I found myself wishing that I didn't have to commit a bunch of difficult to read strings for repeatable access to the mock data. To address this, I've introduced a subscript to `HaversackEphemeralStrategy` so that developers can access `mockData` via the queries they already have.

I did consider adding a pair of `setValue`/`getValue` functions but thought that the subscript access would be more ergonomic, especially considering that `HaversackEphemeralStrategy` is essentially just a wrapper around `mockData` (excluding key import/export).