### PR TITLE
Fix Haversack.search only returning a single item

### DIFF
--- a/Sources/Haversack/Haversack.swift
+++ b/Sources/Haversack/Haversack.swift
@@ -80,7 +80,7 @@ public struct Haversack {
         configuration.serialQueue.async {
             let result: Result<[T.Entity], Error>
             do {
-                let localQuery = try makeSearchQuery(query, singleItem: true)
+                let localQuery = try makeSearchQuery(query, singleItem: false)
 
                 let entities = try self.configuration.strategy.search(localQuery)
                 result = .success(entities)


### PR DESCRIPTION
This bug was introduced in the effort to improve `HaversackEphemeralStrategy` ergonomics. As of writing, those changes haven't been tagged and released so this isn't urgent.

I was unable to write a unit test for this because searches for both single and multiple items include the `kSecMatchLimit` ([source](https://github.com/jamf/Haversack/blob/a02118c07e17acc916cadda05b9f6b15f0968ac3/Sources/Haversack/Haversack.swift#L472)).  This means that the dictionary keys generated by the ephemeral strategy look identical (`classkeyslablexamm_Limitm_Lir_Data` vs `classkeyslablexamm_Limitm_Lir_Data`). I could, of course, change the key generation strategy but that would break unit tests for consumers of this library. 

Since I couldn't write tests, I did a manual review of calls to `makeSearchQuery` and the other query builder functions to double check there were no other similar errors.