### PR TITLE
Updates to allow building using Swift 6

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright 2024, Jamf
+# Copyright 2026, Jamf
 
 name: UnitTests
 
@@ -11,29 +11,29 @@ on:
 
 jobs:
   Test-on-macOS:
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run macOS tests (including integration)
       run: swift test
 
   Test-on-all-others:
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run iOS tests
-      run: xcodebuild test -scheme Haversack-Package -destination 'platform=iOS Simulator,name=iPhone 14'
+      run: xcodebuild test -scheme Haversack-Package -destination 'platform=iOS Simulator,name=iPhone 17'
     - name: Run tvOS tests
       run: xcodebuild test -scheme Haversack-Package -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'
     - name: Run watchOS tests
-      run: xcodebuild test -scheme Haversack-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm)'
+      run: xcodebuild test -scheme Haversack-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm)'
 
   SwiftLint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: GitHub Action for SwiftLint
       uses: norio-nomura/action-swiftlint@3.2.1

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,7 +12,7 @@ file_header:
   severity: error
   required_pattern: |
                     \/\/ SPDX-License-Identifier: MIT
-                    \/\/ Copyright 2023, Jamf
+                    \/\/ Copyright 2026, Jamf
 
 opt_in_rules:
   - contains_over_filter_count

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -3,7 +3,7 @@
 <dict>
     <key>FILEHEADER</key>
     <string> SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf</string>
+// Copyright ___YEAR___, Jamf</string>
 </dict>
 </plist>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [1.4.0] - 2026-03-18
 ### Added
 - Added convenience methods for accessing mock data values on the `HaversackEphemeralStrategy`
+- Added `Sendable` conformance to all public types, protocols, and enums.
+
+### Changed
+- Updated to build using Swift 6.
+- Entity types (`CertificateEntity`, `GenericPasswordEntity`, `InternetPasswordEntity`, `IdentityEntity`, `KeyEntity`) converted from classes to structs.
+- `PasswordBaseEntity` converted from a base class to a protocol with default implementations.
+- `KeychainStorable` protocol now requires `Equatable` conformance.
+- `KeychainFile` is now a `final class`.
+- Query and configuration properties use `NSLock` for thread-safe access.
+- Internal `CFString` dictionary keys migrated to `String` for `Sendable` compatibility.
+- Completion handlers and closure properties marked `@Sendable`.
 
 ## [1.3.0] - 2024-02-11
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2024, Jamf
+Copyright 2026, Jamf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     },
     {
@@ -14,14 +14,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "1e8d1be934506e4d316e2641b2d7865446ce4127f1b788ae0666980934dca51c",
   "pins" : [
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
-        "version" : "1.4.6"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
@@ -28,5 +29,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version:5.9
+// swift-tools-version: 5.10
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import PackageDescription
 
@@ -10,7 +10,7 @@ let package = Package(
         .macOS(.v10_13),
         .iOS(.v12),
         .tvOS(.v12),
-		.visionOS(.v1),
+        .visionOS(.v1),
         .watchOS(.v5)
     ],
     products: [
@@ -24,14 +24,15 @@ let package = Package(
     ],
     targets: [
         .target(name: "Haversack",
-				dependencies: [
+                dependencies: [
                     .product(name: "OrderedCollections", package: "swift-collections")
-				],
-				resources: [.process("Resources/")]),
+                ],
+                resources: [.process("Resources/")]),
         .target(name: "HaversackCryptoKit", dependencies: ["Haversack"]),
         .target(name: "HaversackMock", dependencies: ["Haversack"]),
         .testTarget(name: "HaversackTests",
                     dependencies: ["HaversackMock"],
                     resources: [.copy("TestResources/")])
-    ]
+    ],
+    swiftLanguageVersions: [.v5, .version("6")]
 )

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Save a password for a website:
 
 ```swift
     let myHaversack = Haversack()
-    let newPassword = InternetPasswordEntity()
+    var newPassword = InternetPasswordEntity()
     newPassword.protocol = .HTTPS
     newPassword.server = "test.example.com"
     newPassword.account = "mine"
@@ -145,3 +145,4 @@ Before submitting your pull request, please do the following:
 
 - Kyle Hammond
 - Jacob Hearst
+- Michael Link

--- a/Sources/Haversack/Entities/CertificateEntity.swift
+++ b/Sources/Haversack/Entities/CertificateEntity.swift
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import OrderedCollections
 
 /// Represents a certificate in the keychain.
-public class CertificateEntity: KeychainStorable, KeychainPortable {
+public struct CertificateEntity: KeychainStorable, KeychainPortable {
     /// Uses the `SecCertificate` type to interface with the Security framework.
     public typealias SecurityFrameworkType = SecCertificate
 
@@ -58,8 +58,8 @@ public class CertificateEntity: KeychainStorable, KeychainPortable {
     /// The `subjectData` parsed into a dictionary of OIDs to names; read only.
     public private(set) var subjectStrings: OrderedDictionary<String, String>?
 
-    public required init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
-                         attributes: [String: Any]?, persistentRef: Data?) {
+    public init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
+                attributes: [String: Any]?, persistentRef: Data?) {
         reference = keychainItemRef
         certificateData = data
         self.persistentRef = persistentRef
@@ -90,7 +90,7 @@ public class CertificateEntity: KeychainStorable, KeychainPortable {
 
     /// A simple initializer to use with an existing `SecCertificate` not in the keychain.
     /// - Parameter keychainItemRef: A `SecCertificate` that is not in a keychain.
-    public convenience init(from keychainItemRef: SecCertificate) {
+    public init(from keychainItemRef: SecCertificate) {
         self.init(from: keychainItemRef, data: nil, attributes: nil, persistentRef: nil)
     }
 

--- a/Sources/Haversack/Entities/Data+X501Name.swift
+++ b/Sources/Haversack/Entities/Data+X501Name.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import OrderedCollections

--- a/Sources/Haversack/Entities/GenericPasswordEntity.swift
+++ b/Sources/Haversack/Entities/GenericPasswordEntity.swift
@@ -1,12 +1,85 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
+@preconcurrency import Security
 
 /// Represents a password to anything in the keychain.
 ///
 /// The combination of `service` and `account` values is unique per generic password in the keychain.
-public class GenericPasswordEntity: PasswordBaseEntity {
+public struct GenericPasswordEntity: PasswordBaseEntity {
+#if os(macOS)
+    /// The native Security framework type associated with `PasswordBaseEntity`
+    ///
+    /// On macOS uses the `SecKeychainItem` type to interface with the Security framework.
+    /// On iOS uses the [Data](https://developer.apple.com/documentation/Foundation/Data)
+    /// type to interface with the Security framework.
+    public typealias SecurityFrameworkType = SecKeychainItem
+#else
+    /// The native Security framework type associated with `PasswordBaseEntity`
+    ///
+    /// On macOS uses the `SecKeychainItem` type to interface with the Security framework.
+    /// On iOS uses the [Data](https://developer.apple.com/documentation/Foundation/Data)
+    /// type to interface with the Security framework.
+    public typealias SecurityFrameworkType = Data
+#endif
+
+    /// The keychain item reference, if it has been returned.
+    public var reference: SecurityFrameworkType?
+
+    /// The persistent keychain item reference, if it has been returned.
+    public var persistentRef: Data?
+
+    /// When the item was created; read only.
+    /// - Note: Uses `kSecAttrCreationDate`
+    public private(set) var creationDate: Date?
+
+    /// When the item was last modified; read only.
+    /// - Note: Uses `kSecAttrModificationDate`
+    public private(set) var modificationDate: Date?
+
+    /// The item's creator.
+    /// - Note: Uses `kSecAttrCreator`
+    public var creator: Int?    // FourCharCode
+
+    /// A description to store alongside the item.
+    ///
+    /// In Keychain Access this is the `Kind` field.
+    /// - Note: Uses `kSecAttrDescription`
+    public var description: String?
+
+    /// A comment to store alongside the item.
+    ///
+    /// In Keychain Access this is the `Comment` field.
+    /// - Note: Uses `kSecAttrComment`.
+    public var comment: String?
+
+    /// User-defined group number for passwords
+    /// - Note: Uses `kSecAttrType`
+    public var group: Int?     // FourCharCode
+
+    /// A user-visible label for the item.
+    ///
+    /// In Keychain Access this is the `Name` field.
+    /// - Note: Uses `kSecAttrLabel`
+    public var label: String?
+
+    /// Whether you want this to show up in Keychain Access.
+    /// - Note: Uses `kSecAttrIsInvisible`
+    public var isInvisible: Bool?
+
+    /// The name of an account within a service associated with the password.
+    ///
+    /// In Keychain Access this is the `Account` field.
+    /// - Note: Uses `kSecAttrAccount`
+    public var account: String?
+
+    /// The actual password.
+    ///
+    /// If this is nil, when saving to the keychain the `kSecAttrIsNegative` is set to `true` instead.
+    /// - Note: Uses `kSecValueData`.
+    public var passwordData: Data?
+
     /// The name of the service associated with the password.
     ///
     /// In Keychain Access this is the `Where` field.
@@ -18,8 +91,8 @@ public class GenericPasswordEntity: PasswordBaseEntity {
     public var customData: Data?
 
     /// Create an empty generic password entity
-    override public init() {
-        super.init()
+    public init() {
+        // Everything is nil with this constructor.
     }
 
     /// Returns a ``GenericPasswordEntity`` object initialized to correspond to an existing keychain item.
@@ -28,11 +101,21 @@ public class GenericPasswordEntity: PasswordBaseEntity {
     ///   - data: If given, the raw unencrypted data of the password.
     ///   - attributes: If given, the attributes of an existing keychain item.
     ///   - persistentRef: If given, a persistent reference to an existing keychain item.
-    public required init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
-                         attributes: [String: Any]?, persistentRef: Data?) {
-        super.init(from: keychainItemRef, data: data, attributes: attributes, persistentRef: persistentRef)
+    public init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
+                attributes: [String: Any]?, persistentRef: Data?) {
+        reference = keychainItemRef
+        passwordData = data
+        self.persistentRef = persistentRef
 
         if let attrs = attributes {
+            creationDate = attrs[kSecAttrCreationDate as String] as? Date
+            modificationDate = attrs[kSecAttrModificationDate as String] as? Date
+            label = attrs[kSecAttrLabel as String] as? String
+            account = attrs[kSecAttrAccount as String] as? String
+            group = attrs[kSecAttrType as String] as? Int
+            comment = attrs[kSecAttrComment as String] as? String
+            description = attrs[kSecAttrDescription as String] as? String
+            creator = attrs[kSecAttrCreator as String] as? Int
             service = attrs[kSecAttrService as String] as? String
             customData = attrs[kSecAttrGeneric as String] as? Data
         }
@@ -40,8 +123,8 @@ public class GenericPasswordEntity: PasswordBaseEntity {
 
     // MARK: - KeychainStorable
 
-    override public func entityQuery(includeSecureData: Bool) -> SecurityFrameworkQuery {
-        var query = super.entityQuery(includeSecureData: includeSecureData)
+    public func entityQuery(includeSecureData: Bool) -> SecurityFrameworkQuery {
+        var query = _entityQuery(includeSecureData: includeSecureData)
 
         query[kSecClass as String] = kSecClassGenericPassword
 

--- a/Sources/Haversack/Entities/IdentityEntity.swift
+++ b/Sources/Haversack/Entities/IdentityEntity.swift
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
+@preconcurrency import Security
 
 /// Represents a certificate plus private key in the keychain.
-public class IdentityEntity: KeychainStorable, KeychainPortable {
+public struct IdentityEntity: KeychainStorable, KeychainPortable {
     /// Uses the `SecIdentity` type to interface with the Security framework.
     public typealias SecurityFrameworkType = SecIdentity
 
@@ -20,8 +21,8 @@ public class IdentityEntity: KeychainStorable, KeychainPortable {
     /// When requesting attributes, this is filled with the certificate info from the identity; read only.
     public var certificate: CertificateEntity?
 
-    public required init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
-                         attributes: [String: Any]?, persistentRef: Data?) {
+    public init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
+                attributes: [String: Any]?, persistentRef: Data?) {
 
         reference = keychainItemRef
         self.persistentRef = persistentRef

--- a/Sources/Haversack/Entities/InternetPasswordEntity.swift
+++ b/Sources/Haversack/Entities/InternetPasswordEntity.swift
@@ -1,12 +1,85 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
+@preconcurrency import Security
 
 /// Represents a password to an account on another computer or website in the keychain.
 ///
 /// The combination of `server` and `account` values is unique per internet password in the keychain.
-public class InternetPasswordEntity: PasswordBaseEntity {
+public struct InternetPasswordEntity: PasswordBaseEntity {
+#if os(macOS)
+    /// The native Security framework type associated with `PasswordBaseEntity`
+    ///
+    /// On macOS uses the `SecKeychainItem` type to interface with the Security framework.
+    /// On iOS uses the [Data](https://developer.apple.com/documentation/Foundation/Data)
+    /// type to interface with the Security framework.
+    public typealias SecurityFrameworkType = SecKeychainItem
+#else
+    /// The native Security framework type associated with `PasswordBaseEntity`
+    ///
+    /// On macOS uses the `SecKeychainItem` type to interface with the Security framework.
+    /// On iOS uses the [Data](https://developer.apple.com/documentation/Foundation/Data)
+    /// type to interface with the Security framework.
+    public typealias SecurityFrameworkType = Data
+#endif
+
+    /// The keychain item reference, if it has been returned.
+    public var reference: SecurityFrameworkType?
+
+    /// The persistent keychain item reference, if it has been returned.
+    public var persistentRef: Data?
+
+    /// When the item was created; read only.
+    /// - Note: Uses `kSecAttrCreationDate`
+    public private(set) var creationDate: Date?
+
+    /// When the item was last modified; read only.
+    /// - Note: Uses `kSecAttrModificationDate`
+    public private(set) var modificationDate: Date?
+
+    /// The item's creator.
+    /// - Note: Uses `kSecAttrCreator`
+    public var creator: Int?    // FourCharCode
+
+    /// A description to store alongside the item.
+    ///
+    /// In Keychain Access this is the `Kind` field.
+    /// - Note: Uses `kSecAttrDescription`
+    public var description: String?
+
+    /// A comment to store alongside the item.
+    ///
+    /// In Keychain Access this is the `Comment` field.
+    /// - Note: Uses `kSecAttrComment`.
+    public var comment: String?
+
+    /// User-defined group number for passwords
+    /// - Note: Uses `kSecAttrType`
+    public var group: Int?     // FourCharCode
+
+    /// A user-visible label for the item.
+    ///
+    /// In Keychain Access this is the `Name` field.
+    /// - Note: Uses `kSecAttrLabel`
+    public var label: String?
+
+    /// Whether you want this to show up in Keychain Access.
+    /// - Note: Uses `kSecAttrIsInvisible`
+    public var isInvisible: Bool?
+
+    /// The name of an account within a service associated with the password.
+    ///
+    /// In Keychain Access this is the `Account` field.
+    /// - Note: Uses `kSecAttrAccount`
+    public var account: String?
+
+    /// The actual password.
+    ///
+    /// If this is nil, when saving to the keychain the `kSecAttrIsNegative` is set to `true` instead.
+    /// - Note: Uses `kSecValueData`.
+    public var passwordData: Data?
+
     /// The Internet security domain.
     /// - Note: Uses `kSecAttrSecurityDomain`
     public var securityDomain: String?
@@ -17,7 +90,7 @@ public class InternetPasswordEntity: PasswordBaseEntity {
 
     /// A communications protocol for internet passwords.
     /// - Note: Mirrors the `kSecAttrProtocol...` constants.
-    public enum NetworkProtocol {
+    public enum NetworkProtocol: Sendable {
         case FTP
         case FTPAccount
         case HTTP
@@ -50,46 +123,46 @@ public class InternetPasswordEntity: PasswordBaseEntity {
         case IRCS
         case POP3S
 
-        private static let translation: [CFString: NetworkProtocol] = [
-            kSecAttrProtocolFTP: FTP,
-            kSecAttrProtocolFTPAccount: FTPAccount,
-            kSecAttrProtocolHTTP: HTTP,
-            kSecAttrProtocolIRC: IRC,
-            kSecAttrProtocolNNTP: NNTP,
-            kSecAttrProtocolPOP3: POP3,
-            kSecAttrProtocolSMTP: SMTP,
-            kSecAttrProtocolSOCKS: SOCKS,
-            kSecAttrProtocolIMAP: IMAP,
-            kSecAttrProtocolLDAP: LDAP,
-            kSecAttrProtocolAppleTalk: appleTalk,
-            kSecAttrProtocolAFP: AFP,
-            kSecAttrProtocolTelnet: telnet,
-            kSecAttrProtocolSSH: SSH,
-            kSecAttrProtocolFTPS: FTPS,
-            kSecAttrProtocolHTTPS: HTTPS,
-            kSecAttrProtocolHTTPProxy: HTTPProxy,
-            kSecAttrProtocolHTTPSProxy: HTTPSProxy,
-            kSecAttrProtocolFTPProxy: FTPProxy,
-            kSecAttrProtocolSMB: SMB,
-            kSecAttrProtocolRTSP: RTSP,
-            kSecAttrProtocolRTSPProxy: RTSPProxy,
-            kSecAttrProtocolDAAP: DAAP,
-            kSecAttrProtocolEPPC: EPPC,
-            kSecAttrProtocolIPP: IPP,
-            kSecAttrProtocolNNTPS: NNTPS,
-            kSecAttrProtocolLDAPS: LDAPS,
-            kSecAttrProtocolTelnetS: telnetS,
-            kSecAttrProtocolIMAPS: IMAPS,
-            kSecAttrProtocolIRCS: IRCS,
-            kSecAttrProtocolPOP3S: POP3S
+        private static let translation: [String: NetworkProtocol] = [
+            kSecAttrProtocolFTP as String: FTP,
+            kSecAttrProtocolFTPAccount as String: FTPAccount,
+            kSecAttrProtocolHTTP as String: HTTP,
+            kSecAttrProtocolIRC as String: IRC,
+            kSecAttrProtocolNNTP as String: NNTP,
+            kSecAttrProtocolPOP3 as String: POP3,
+            kSecAttrProtocolSMTP as String: SMTP,
+            kSecAttrProtocolSOCKS as String: SOCKS,
+            kSecAttrProtocolIMAP as String: IMAP,
+            kSecAttrProtocolLDAP as String: LDAP,
+            kSecAttrProtocolAppleTalk as String: appleTalk,
+            kSecAttrProtocolAFP as String: AFP,
+            kSecAttrProtocolTelnet as String: telnet,
+            kSecAttrProtocolSSH as String: SSH,
+            kSecAttrProtocolFTPS as String: FTPS,
+            kSecAttrProtocolHTTPS as String: HTTPS,
+            kSecAttrProtocolHTTPProxy as String: HTTPProxy,
+            kSecAttrProtocolHTTPSProxy as String: HTTPSProxy,
+            kSecAttrProtocolFTPProxy as String: FTPProxy,
+            kSecAttrProtocolSMB as String: SMB,
+            kSecAttrProtocolRTSP as String: RTSP,
+            kSecAttrProtocolRTSPProxy as String: RTSPProxy,
+            kSecAttrProtocolDAAP as String: DAAP,
+            kSecAttrProtocolEPPC as String: EPPC,
+            kSecAttrProtocolIPP as String: IPP,
+            kSecAttrProtocolNNTPS as String: NNTPS,
+            kSecAttrProtocolLDAPS as String: LDAPS,
+            kSecAttrProtocolTelnetS as String: telnetS,
+            kSecAttrProtocolIMAPS as String: IMAPS,
+            kSecAttrProtocolIRCS as String: IRCS,
+            kSecAttrProtocolPOP3S as String: POP3S
         ]
 
         static func make(from securityFrameworkValue: CFString) -> NetworkProtocol? {
-            return translation[securityFrameworkValue]
+            return translation[securityFrameworkValue as String]
         }
 
         func securityFrameworkValue() -> CFString {
-            return Self.translation.first(where: { $1 == self })!.key
+            return Self.translation.first(where: { $1 == self })!.key as CFString
         }
     }
 
@@ -99,7 +172,7 @@ public class InternetPasswordEntity: PasswordBaseEntity {
 
     /// An authentication scheme for internet passwords.
     /// - Note: Mirrors the `kSecAttrAuthenticationType...` constants.
-    public enum AuthenticationType {
+    public enum AuthenticationType: Sendable {
         case NTLM
         case MSN
         case DPA
@@ -109,23 +182,23 @@ public class InternetPasswordEntity: PasswordBaseEntity {
         case HTMLForm
         case `default`
 
-        private static let translation: [CFString: AuthenticationType] = [
-            kSecAttrAuthenticationTypeNTLM: NTLM,
-            kSecAttrAuthenticationTypeMSN: MSN,
-            kSecAttrAuthenticationTypeDPA: DPA,
-            kSecAttrAuthenticationTypeRPA: RPA,
-            kSecAttrAuthenticationTypeHTTPBasic: HTTPBasic,
-            kSecAttrAuthenticationTypeHTTPDigest: HTTPDigest,
-            kSecAttrAuthenticationTypeHTMLForm: HTMLForm,
-            kSecAttrAuthenticationTypeDefault: `default`
+        private static let translation: [String: AuthenticationType] = [
+            kSecAttrAuthenticationTypeNTLM as String: NTLM,
+            kSecAttrAuthenticationTypeMSN as String: MSN,
+            kSecAttrAuthenticationTypeDPA as String: DPA,
+            kSecAttrAuthenticationTypeRPA as String: RPA,
+            kSecAttrAuthenticationTypeHTTPBasic as String: HTTPBasic,
+            kSecAttrAuthenticationTypeHTTPDigest as String: HTTPDigest,
+            kSecAttrAuthenticationTypeHTMLForm as String: HTMLForm,
+            kSecAttrAuthenticationTypeDefault as String: `default`
         ]
 
         static func make(from securityFrameworkValue: CFString) -> AuthenticationType? {
-            return translation[securityFrameworkValue]
+            return translation[securityFrameworkValue as String]
         }
 
         func securityFrameworkValue() -> CFString {
-            return Self.translation.first(where: { $1 == self })!.key
+            return Self.translation.first(where: { $1 == self })!.key as CFString
         }
     }
 
@@ -142,23 +215,37 @@ public class InternetPasswordEntity: PasswordBaseEntity {
     public var path: String?
 
     /// Create an empty internet password entity
-    override public init() {
-        super.init()
+    public init() {
+        // Everything is nil with this constructor.
     }
 
-    public required init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
-                         attributes: [String: Any]?, persistentRef: Data?) {
-        super.init(from: keychainItemRef, data: data, attributes: attributes, persistentRef: persistentRef)
+    public init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
+                attributes: [String: Any]?, persistentRef: Data?) {
+        reference = keychainItemRef
+        passwordData = data
+        self.persistentRef = persistentRef
 
         if let attrs = attributes {
+            creationDate = attrs[kSecAttrCreationDate as String] as? Date
+            modificationDate = attrs[kSecAttrModificationDate as String] as? Date
+            label = attrs[kSecAttrLabel as String] as? String
+            account = attrs[kSecAttrAccount as String] as? String
+            group = attrs[kSecAttrType as String] as? Int
+            comment = attrs[kSecAttrComment as String] as? String
+            description = attrs[kSecAttrDescription as String] as? String
+            creator = attrs[kSecAttrCreator as String] as? Int
+
             securityDomain = attrs[kSecAttrSecurityDomain as String] as? String
             server = attrs[kSecAttrServer as String] as? String
+
             if let possibleProtocol = attrs[kSecAttrProtocol as String] as? String {
                 `protocol` = .make(from: possibleProtocol as CFString)
             }
+
             if let possibleAuthType = attrs[kSecAttrAuthenticationType as String] as? String {
                 authenticationType = .make(from: possibleAuthType as CFString)
             }
+
             port = attrs[kSecAttrPort as String] as? Int
             path = attrs[kSecAttrPath as String] as? String
         }
@@ -166,8 +253,8 @@ public class InternetPasswordEntity: PasswordBaseEntity {
 
     // MARK: - KeychainStorable
 
-    override public func entityQuery(includeSecureData: Bool) -> SecurityFrameworkQuery {
-        var query = super.entityQuery(includeSecureData: includeSecureData)
+    public func entityQuery(includeSecureData: Bool) -> SecurityFrameworkQuery {
+        var query = _entityQuery(includeSecureData: includeSecureData)
 
         query[kSecClass as String] = kSecClassInternetPassword
 

--- a/Sources/Haversack/Entities/KeyEntity.swift
+++ b/Sources/Haversack/Entities/KeyEntity.swift
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
+@preconcurrency import Security
 
 /// Represents a public or private key in the keychain.
-public class KeyEntity: KeychainStorable, KeychainPortable {
+public struct KeyEntity: KeychainStorable, KeychainPortable {
     /// Uses the `SecKey` type to interface with the Security framework.
     public typealias SecurityFrameworkType = SecKey
 
@@ -53,8 +54,8 @@ public class KeyEntity: KeychainStorable, KeychainPortable {
     /// Create an empty key entity
     public init() { }
 
-    public required init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
-                         attributes: [String: Any]?, persistentRef: Data?) {
+    public init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
+                attributes: [String: Any]?, persistentRef: Data?) {
         reference = keychainItemRef
         keyData = data
         self.persistentRef = persistentRef

--- a/Sources/Haversack/Entities/KeychainStorable.swift
+++ b/Sources/Haversack/Entities/KeychainStorable.swift
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
 /// Represents any item that is storable in the keychain.
-public protocol KeychainStorable {
+public protocol KeychainStorable: Equatable, Sendable {
     /// This should be one of the SecFoo types, such as `SecCertificate` or `SecKeychainItem`
-    associatedtype SecurityFrameworkType
+    associatedtype SecurityFrameworkType: Sendable
 
     /// The keychain item reference, if it has been returned.
     var reference: SecurityFrameworkType? { get }

--- a/Sources/Haversack/Entities/PasswordBaseEntity.swift
+++ b/Sources/Haversack/Entities/PasswordBaseEntity.swift
@@ -1,113 +1,84 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
 /// Superclass of the ``GenericPasswordEntity`` and the ``InternetPasswordEntity`` that
 /// handles storage and minor processing of shared data fields.  The `PasswordBaseEntity` is never
 /// instantiated on its own.
-public class PasswordBaseEntity: KeychainStorable {
-#if os(macOS)
-    /// The native Security framework type associated with `PasswordBaseEntity`
-    ///
-    /// On macOS uses the `SecKeychainItem` type to interface with the Security framework.
-    /// On iOS uses the [Data](https://developer.apple.com/documentation/Foundation/Data)
-    /// type to interface with the Security framework.
-    public typealias SecurityFrameworkType = SecKeychainItem
-#else
-    /// The native Security framework type associated with `PasswordBaseEntity`
-    ///
-    /// On macOS uses the `SecKeychainItem` type to interface with the Security framework.
-    /// On iOS uses the [Data](https://developer.apple.com/documentation/Foundation/Data)
-    /// type to interface with the Security framework.
-    public typealias SecurityFrameworkType = Data
-#endif
-
+public protocol PasswordBaseEntity: KeychainStorable {
     /// The keychain item reference, if it has been returned.
-    public var reference: SecurityFrameworkType?
+    var reference: SecurityFrameworkType? { get set }
 
     /// The persistent keychain item reference, if it has been returned.
-    public var persistentRef: Data?
+    var persistentRef: Data? { get set }
 
     /// When the item was created; read only.
     /// - Note: Uses `kSecAttrCreationDate`
-    private(set) var creationDate: Date?
+    var creationDate: Date? { get }
 
     /// When the item was last modified; read only.
     /// - Note: Uses `kSecAttrModificationDate`
-    private(set) var modificationDate: Date?
+    var modificationDate: Date? { get }
 
     /// The item's creator.
     /// - Note: Uses `kSecAttrCreator`
-    public var creator: Int?    // FourCharCode
+    var creator: Int? { get set }    // FourCharCode
 
     /// A description to store alongside the item.
     ///
     /// In Keychain Access this is the `Kind` field.
     /// - Note: Uses `kSecAttrDescription`
-    public var description: String?
+    var description: String? { get set }
 
     /// A comment to store alongside the item.
     ///
     /// In Keychain Access this is the `Comment` field.
     /// - Note: Uses `kSecAttrComment`.
-    public var comment: String?
+    var comment: String? { get set }
 
     /// User-defined group number for passwords
     /// - Note: Uses `kSecAttrType`
-    public var group: Int?     // FourCharCode
+    var group: Int? { get set }    // FourCharCode
 
     /// A user-visible label for the item.
     ///
     /// In Keychain Access this is the `Name` field.
     /// - Note: Uses `kSecAttrLabel`
-    public var label: String?
+    var label: String? { get set }
 
     /// Whether you want this to show up in Keychain Access.
     /// - Note: Uses `kSecAttrIsInvisible`
-    public var isInvisible: Bool?
+    var isInvisible: Bool? { get set }
 
     /// Useful if you want to never store the actual password, but still have a keychain item.
-    public var isNegative: Bool {
-        return passwordData == nil
-    }
+    var isNegative: Bool { get }
 
     /// The name of an account within a service associated with the password.
     ///
     /// In Keychain Access this is the `Account` field.
     /// - Note: Uses `kSecAttrAccount`
-    public var account: String?
+    var account: String? { get set }
 
     /// The actual password.
     ///
     /// If this is nil, when saving to the keychain the `kSecAttrIsNegative` is set to `true` instead.
     /// - Note: Uses `kSecValueData`.
-    public var passwordData: Data?
-
-    /// Everything is nil with this constructor.
-    public init() { }
-
-    public required init(from keychainItemRef: SecurityFrameworkType?, data: Data?,
-                         attributes: [String: Any]?, persistentRef: Data?) {
-        reference = keychainItemRef
-        passwordData = data
-        self.persistentRef = persistentRef
-
-        if let attrs = attributes {
-            creationDate = attrs[kSecAttrCreationDate as String] as? Date
-            modificationDate = attrs[kSecAttrModificationDate as String] as? Date
-            label = attrs[kSecAttrLabel as String] as? String
-            account = attrs[kSecAttrAccount as String] as? String
-            group = attrs[kSecAttrType as String] as? Int
-            comment = attrs[kSecAttrComment as String] as? String
-            description = attrs[kSecAttrDescription as String] as? String
-            creator = attrs[kSecAttrCreator as String] as? Int
-        }
-    }
+    var passwordData: Data? { get set }
 
     // NOTE: This function has a cyclomatic complexity of 11 instead of the allowed 10.
     // swiftlint:disable:next cyclomatic_complexity
-    public func entityQuery(includeSecureData: Bool) -> SecurityFrameworkQuery {
+    func entityQuery(includeSecureData: Bool) -> SecurityFrameworkQuery
+}
+
+extension PasswordBaseEntity {
+    /// Useful if you want to never store the actual password, but still have a keychain item.
+    public var isNegative: Bool {
+        return passwordData == nil
+    }
+
+    // swiftlint:disable:next identifier_name
+    func _entityQuery(includeSecureData: Bool) -> SecurityFrameworkQuery {
         var newQuery = SecurityFrameworkQuery()
 
         if let theReference = reference {

--- a/Sources/Haversack/Entities/PasswordBaseEntity.swift
+++ b/Sources/Haversack/Entities/PasswordBaseEntity.swift
@@ -3,9 +3,8 @@
 
 import Foundation
 
-/// Superclass of the ``GenericPasswordEntity`` and the ``InternetPasswordEntity`` that
-/// handles storage and minor processing of shared data fields.  The `PasswordBaseEntity` is never
-/// instantiated on its own.
+/// Protocol for the ``GenericPasswordEntity`` and the ``InternetPasswordEntity``
+/// that handles storage and minor processing of shared data fields.
 public protocol PasswordBaseEntity: KeychainStorable {
     /// The keychain item reference, if it has been returned.
     var reference: SecurityFrameworkType? { get set }

--- a/Sources/Haversack/GenericPasswordConvertible.swift
+++ b/Sources/Haversack/GenericPasswordConvertible.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import os.log
@@ -7,7 +7,7 @@ import os.log
 /// Protocol to use with any type that can be converted to a [Data](https://developer.apple.com/documentation/Foundation/Data) representation.
 ///
 /// The type can be stored in the keychain as a generic password using the ``GenericPasswordEntity`` type.
-public protocol GenericPasswordConvertible {
+public protocol GenericPasswordConvertible: Sendable {
     /// A raw representation of the thing.
     var rawRepresentation: Data { get }
 
@@ -23,7 +23,7 @@ extension GenericPasswordEntity {
     /// > Tip: In order to persist the value to the keychain, one of the Haversack `save()` methods should be called
     /// with the initialized ``GenericPasswordEntity``.
     /// - Parameter convertible: Any type that can be converted to plain [Data](https://developer.apple.com/documentation/Foundation/Data)
-    public convenience init<T: GenericPasswordConvertible>(_ convertible: T) {
+    public init<T: GenericPasswordConvertible>(_ convertible: T) {
         self.init(from: nil, data: convertible.rawRepresentation, attributes: nil, persistentRef: nil)
     }
 

--- a/Sources/Haversack/Haversack+AsyncAwait.swift
+++ b/Sources/Haversack/Haversack+AsyncAwait.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 

--- a/Sources/Haversack/Haversack.swift
+++ b/Sources/Haversack/Haversack.swift
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
+@preconcurrency import Security
 
 /// Represents a connection to a keychain.
 ///
 /// Contains keychain search functionality and the ability to add/update/delete items in the keychain.
-public struct Haversack {
+public struct Haversack: Sendable {
     /// The configuration that the Haversack was created with.
     public let configuration: HaversackConfiguration
 
@@ -39,7 +40,7 @@ public struct Haversack {
     ///   - completion: A function/block to be called when the search operation is completed.
     ///   - result: The item or an error will be given to the completion handler.
     public func first<T: KeychainQuerying>(where query: T, completionQueue: OperationQueue? = nil,
-                                           completion: @escaping (_ result: Result<T.Entity, Error>) -> Void) {
+                                           completion: @escaping @Sendable (_ result: sending Result<T.Entity, Error>) -> Void) {
         configuration.serialQueue.async {
             let result: Result<T.Entity, Error>
             do {
@@ -76,7 +77,7 @@ public struct Haversack {
     ///   - completion: A function/block to be called when the search operation is completed.
     ///   - result: An array of items or an error will be given to the completion handler.
     public func search<T: KeychainQuerying>(where query: T, completionQueue: OperationQueue? = nil,
-                                            completion: @escaping (_ result: Result<[T.Entity], Error>) -> Void) {
+                                            completion: @escaping @Sendable (_ result: sending Result<[T.Entity], Error>) -> Void) {
         configuration.serialQueue.async {
             let result: Result<[T.Entity], Error>
             do {
@@ -121,7 +122,7 @@ public struct Haversack {
     ///   - result: The original `item` that was saved or an error will be given to the completion handler.
     public func save<T: KeychainStorable>(_ item: T, itemSecurity: ItemSecurity, updateExisting: Bool,
                                           completionQueue: OperationQueue? = nil,
-                                          completion: @escaping (_ result: Result<T, Error>) -> Void) {
+                                          completion: @escaping @Sendable (_ result: sending Result<T, Error>) -> Void) {
         configuration.serialQueue.async {
             let result: Result<T, Error>
 
@@ -167,7 +168,7 @@ public struct Haversack {
     ///   block; a `nil` represents no error.
     public func delete<T: KeychainStorable>(_ item: T, treatNotFoundAsSuccess: Bool = true,
                                             completionQueue: OperationQueue? = nil,
-                                            completion: @escaping (_ error: Error?) -> Void) {
+                                            completion: @escaping @Sendable (_ error: sending Error?) -> Void) {
         configuration.serialQueue.async {
             let result: Error?
 
@@ -212,7 +213,7 @@ public struct Haversack {
     ///   block; a `nil` represents no error.
     public func delete<T: KeychainQuerying>(where query: T, treatNotFoundAsSuccess: Bool = true,
                                             completionQueue: OperationQueue? = nil,
-                                            completion: @escaping (_ error: Error?) -> Void) {
+                                            completion: @escaping @Sendable (_ error: sending Error?) -> Void) {
         configuration.serialQueue.async {
             let result: Error?
 
@@ -296,7 +297,7 @@ public struct Haversack {
     ///   - result: A new `SecKey` or an error.
     public func generateKey(fromConfig config: KeyGenerationConfig, itemSecurity: ItemSecurity,
                             completionQueue: OperationQueue? = nil,
-                            completion: @escaping (_ result: Result<SecKey, Error>) -> Void) {
+                            completion: @escaping @Sendable (_ result: sending Result<SecKey, Error>) -> Void) {
         configuration.serialQueue.async {
             let result: Result<SecKey, Error>
 
@@ -395,8 +396,8 @@ public struct Haversack {
     }
 #endif
 
-    private func call<T>(completionHandler: @escaping (_ result: Result<T, Error>) -> Void,
-                         onQueue queue: OperationQueue?, with result: Result<T, Error>) {
+    private func call<T: Sendable>(completionHandler: @escaping @Sendable (_ result: sending Result<T, Error>) -> Void,
+                                   onQueue queue: OperationQueue?, with result: Result<T, Error>) {
         if let actualQueue = queue {
             actualQueue.addOperation {
                 completionHandler(result)

--- a/Sources/Haversack/HaversackConfiguration.swift
+++ b/Sources/Haversack/HaversackConfiguration.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// Note that if a different queue is specified, all instances of ``Haversack/Haversack`` should be initialized with
 /// the same queue so that all keychain access is done atomically.
-public struct HaversackConfiguration {
+public struct HaversackConfiguration: Sendable {
     /// The `DispatchQueue` to use in order to serialize all keychain access
     ///
     /// If not otherwise specified, a default serial queue will be created with the label "com.jamf.haversack".

--- a/Sources/Haversack/HaversackError.swift
+++ b/Sources/Haversack/HaversackError.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 

--- a/Sources/Haversack/HaversackStrategy.swift
+++ b/Sources/Haversack/HaversackStrategy.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import os.log
@@ -17,7 +17,7 @@ import Security
 /// All item searches are logged at the `.info` level.  Saving and deleting items are logged at
 /// the `.default` level.  All errors are logged at the `.error` level with additional query details logged at
 /// the `.debug` level and marked as private.
-open class HaversackStrategy {
+open class HaversackStrategy: @unchecked Sendable {
     /// Create a new strategy object
     public init() { }
 
@@ -243,7 +243,7 @@ open class HaversackStrategy {
 
         var outItems: CFArray?
         let status = SecItemImport(items as CFData,
-                                   configuration.fileNameOrExtension,
+                                   configuration.fileNameOrExtension as CFString?,
                                    &inputFormat,
                                    &itemType,
                                    configuration.secItemImportFlags,
@@ -272,7 +272,7 @@ open class HaversackStrategy {
 }
 
 /// A simple type that looks into a keychain query to see what kind of data it is asking for.
-private struct QueryContents {
+private struct QueryContents: Sendable {
     let hasRef: Bool
     let hasData: Bool
     let hasPersistentRef: Bool

--- a/Sources/Haversack/ImportExport/KeychainExportConfig.swift
+++ b/Sources/Haversack/ImportExport/KeychainExportConfig.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -7,7 +7,7 @@ import Foundation
 /// Used with ``Haversack`` to export Keychain items
 ///
 /// Create a `KeychainExportConfig` and pass it to ``Haversack/Haversack/exportItems(_:config:)``
-public struct KeychainExportConfig {
+public struct KeychainExportConfig: Sendable {
     // MARK: Public
     public init(outputFormat: SecExternalFormat) {
         self.outputFormat = outputFormat
@@ -33,8 +33,8 @@ public struct KeychainExportConfig {
         switch strategy {
         case .promptUser(let prompt, let title):
             copy.keyImportExportFlags = .securePassphrase
-            copy.alertPrompt = prompt as CFString
-            copy.alertTitle = title as CFString
+            copy.alertPrompt = prompt
+            copy.alertTitle = title
         case .useProvided(let provider):
             copy.passphraseProvider = provider
         }
@@ -51,11 +51,11 @@ public struct KeychainExportConfig {
         params.flags = keyImportExportFlags
 
         if let alertPrompt = alertPrompt {
-            params.alertPrompt = Unmanaged.passRetained(alertPrompt)
+            params.alertPrompt = Unmanaged.passRetained(alertPrompt as CFString)
         }
 
         if let alertTitle = alertTitle {
-            params.alertTitle = Unmanaged.passRetained(alertTitle)
+            params.alertTitle = Unmanaged.passRetained(alertTitle as CFString)
         }
 
         if let passphrase = passphraseProvider {
@@ -66,10 +66,10 @@ public struct KeychainExportConfig {
     }
 
     // MARK: Private
-    private var alertPrompt: CFString?
-    private var alertTitle: CFString?
+    private var alertPrompt: String?
+    private var alertTitle: String?
     /// A function that provides the password to the keychain file.
-    private var passphraseProvider: (() -> String)?
+    private var passphraseProvider: (@Sendable () -> String)?
     private var keyImportExportFlags = SecKeyImportExportFlags()
 }
 #endif

--- a/Sources/Haversack/ImportExport/KeychainImportConfig.swift
+++ b/Sources/Haversack/ImportExport/KeychainImportConfig.swift
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
+@preconcurrency import Security
 
 #if os(macOS)
 /// Used with ``Haversack`` to import Keychain items
 ///
 /// Create a `KeychainImportConfig` and specify what type of keychain item you're importing,
 /// then pass it to ``Haversack/Haversack/importItems(_:config:)``
-public struct KeychainImportConfig<T: KeychainImportable> {
+public struct KeychainImportConfig<T: KeychainImportable>: Sendable {
     public typealias ImportedEntity = T
 
     // MARK: Public
@@ -21,7 +22,7 @@ public struct KeychainImportConfig<T: KeychainImportable> {
     /// - Returns: A `KeychainImportConfig` struct
     public func fileNameOrExtension(_ nameOrExtension: String) -> Self {
         var copy = self
-        copy.fileNameOrExtension = nameOrExtension as CFString
+        copy.fileNameOrExtension = nameOrExtension
 
         return copy
     }
@@ -152,8 +153,8 @@ public struct KeychainImportConfig<T: KeychainImportable> {
         switch strategy {
         case .promptUser(let prompt, let title):
             copy.keyImportFlags.insert(.securePassphrase)
-            copy.alertPrompt = prompt as CFString
-            copy.alertTitle = title as CFString
+            copy.alertPrompt = prompt
+            copy.alertTitle = title
         case .useProvided(let provider):
             copy.passphraseProvider = provider
         }
@@ -163,7 +164,7 @@ public struct KeychainImportConfig<T: KeychainImportable> {
 
     // MARK: Internal
     // SecItemImport parameters
-    var fileNameOrExtension: CFString?
+    var fileNameOrExtension: String?
     var inputFormat: SecExternalFormat = .formatUnknown
     var itemType: SecExternalItemType = .itemTypeUnknown
     var secItemImportFlags = SecItemImportExportFlags()
@@ -172,10 +173,10 @@ public struct KeychainImportConfig<T: KeychainImportable> {
     // SecItemImportExportKeyParameters
     var accessRef: SecAccess?
     var keyUsage: KeyUsagePolicy?
-    var passphraseProvider: (() -> String)?
+    var passphraseProvider: (@Sendable () -> String)?
     var keyImportFlags = SecKeyImportExportFlags()
-    var alertPrompt: CFString?
-    var alertTitle: CFString?
+    var alertPrompt: String?
+    var alertTitle: String?
     var isExtractable: Bool?
     var isPermanent: Bool?
     var isSensitive: Bool?

--- a/Sources/Haversack/ImportExport/KeychainPortable.swift
+++ b/Sources/Haversack/ImportExport/KeychainPortable.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 

--- a/Sources/Haversack/ImportExport/PassphraseStrategy.swift
+++ b/Sources/Haversack/ImportExport/PassphraseStrategy.swift
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
-public enum PassphraseStrategy {
+public enum PassphraseStrategy: Sendable {
     /// Prompt the user to enter the passphrase for the item being imported or exported
     ///
     /// - prompt: The prompt to display in the secure passphrase alert panel
@@ -11,5 +11,5 @@ public enum PassphraseStrategy {
     case promptUser(prompt: String, title: String)
 
     /// Use the password returned by the specified closure instead of prompting the user
-    case useProvided(() -> String)
+    case useProvided(@Sendable () -> String)
 }

--- a/Sources/Haversack/ImportExport/PrivateKeyImporting.swift
+++ b/Sources/Haversack/ImportExport/PrivateKeyImporting.swift
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 #if os(macOS)
 import Foundation
 
 /// Represents a keychain entity that has a private key component
-public protocol PrivateKeyImporting {}
+public protocol PrivateKeyImporting: Sendable {}
 
 extension KeyEntity: PrivateKeyImporting {}
 

--- a/Sources/Haversack/KeyGenerationConfig.swift
+++ b/Sources/Haversack/KeyGenerationConfig.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -7,12 +7,29 @@ import Foundation
 ///
 /// Create a `KeyGenerationConfig` and then pass it to ``Haversack/Haversack/generateKey(fromConfig:itemSecurity:)-1r4ki``
 /// or one of it's asynchronous variants.
-public struct KeyGenerationConfig {
+public struct KeyGenerationConfig: Sendable {
+    private let queryLock = NSLock()
+    private nonisolated(unsafe) var _query = SecurityFrameworkQuery()
     /// The keychain config query.
     ///
     /// You cannot manipulate this directly.  Instead use the fluent methods such as ``labeled(_:)``,
     /// ``tagged(_:)``, and others in order to build up the key generation configuration.
-    public private(set) var query = SecurityFrameworkQuery()
+    public private(set) var query: SecurityFrameworkQuery {
+        @storageRestrictions(initializes: _query)
+        init {
+            _query = newValue
+        }
+        get {
+            queryLock.withLock {
+                _query
+            }
+        }
+        set {
+            queryLock.withLock {
+                _query = newValue
+            }
+        }
+    }
 
     /// Initializer for a key _not_ in the Secure Enclave.
     ///

--- a/Sources/Haversack/KeyGenerationConfig.swift
+++ b/Sources/Haversack/KeyGenerationConfig.swift
@@ -8,28 +8,11 @@ import Foundation
 /// Create a `KeyGenerationConfig` and then pass it to ``Haversack/Haversack/generateKey(fromConfig:itemSecurity:)-1r4ki``
 /// or one of it's asynchronous variants.
 public struct KeyGenerationConfig: Sendable {
-    private let queryLock = NSLock()
-    private nonisolated(unsafe) var _query = SecurityFrameworkQuery()
     /// The keychain config query.
     ///
     /// You cannot manipulate this directly.  Instead use the fluent methods such as ``labeled(_:)``,
     /// ``tagged(_:)``, and others in order to build up the key generation configuration.
-    public private(set) var query: SecurityFrameworkQuery {
-        @storageRestrictions(initializes: _query)
-        init {
-            _query = newValue
-        }
-        get {
-            queryLock.withLock {
-                _query
-            }
-        }
-        set {
-            queryLock.withLock {
-                _query = newValue
-            }
-        }
-    }
+    @NSLocked public var query: SecurityFrameworkQuery = SecurityFrameworkQuery()
 
     /// Initializer for a key _not_ in the Secure Enclave.
     ///

--- a/Sources/Haversack/Logs.swift
+++ b/Sources/Haversack/Logs.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import os.log
 

--- a/Sources/Haversack/NSLocked.swift
+++ b/Sources/Haversack/NSLocked.swift
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026, Jamf
+
+import Foundation
+
+@propertyWrapper
+public struct NSLocked<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T
+    
+    public init(wrappedValue: T) {
+        value = wrappedValue
+    }
+    
+    public var wrappedValue: T {
+        get {
+            lock.withLock {
+                value
+            }
+        }
+        set {
+            lock.withLock {
+                value = newValue
+            }
+        }
+    }
+}

--- a/Sources/Haversack/Queries/CertificateBaseQuerying.swift
+++ b/Sources/Haversack/Queries/CertificateBaseQuerying.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -33,7 +33,7 @@ public protocol CertificateBaseQuerying: KeychainQuerying {
 ///
 /// Refer to the ``KeychainQuerying/stringMatching(options:)-7t0r4`` function and
 /// ``KeychainStringComparisonOptions`` enum for additional ways to modify the string matching.
-public enum CertSubjectMatchType {
+public enum CertSubjectMatchType: Sendable {
     /// The subject of the cert must contain the string, but may have any other prefix and/or suffix.
     ///
     /// Refer to the ``KeychainQuerying/stringMatching(options:)-7t0r4`` function and

--- a/Sources/Haversack/Queries/CertificateQuery.swift
+++ b/Sources/Haversack/Queries/CertificateQuery.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -7,7 +7,24 @@ import Foundation
 ///
 /// Successful searches produce ``CertificateEntity`` objects.
 public struct CertificateQuery {
-    public var query: SecurityFrameworkQuery
+    private let queryLock = NSLock()
+    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
+    public var query: SecurityFrameworkQuery {
+        @storageRestrictions(initializes: _query)
+        init {
+            _query = newValue
+        }
+        get {
+            queryLock.withLock {
+                _query
+            }
+        }
+        set {
+            queryLock.withLock {
+                _query = newValue
+            }
+        }
+    }
 
     /// Create an ``CertificateQuery`` instance
     /// - Parameter label: The keychain label of the item.  Uses `kSecAttrLabel`.
@@ -50,7 +67,7 @@ extension CertificateQuery: CertificateBaseQuerying {
 /// Specifies the type of a certificate.
 ///
 /// Based on `CSSM_CERT_TYPE`.  Used with the `kSecAttrCertificateType` attribute of certificates.
-public enum CertificateType: Int32 {
+public enum CertificateType: Int32, Sendable {
     case unknown = 0
     case x509v1 = 0x01
     case x509v2 = 0x02
@@ -77,7 +94,7 @@ public enum CertificateType: Int32 {
 /// Specifies how a certificate is encoded.
 ///
 /// Based on `CSSM_CERT_ENCODING`.  Used with the `kSecAttrCertificateEncoding` attribute of certificates.
-public enum CertificateEncoding: Int32 {
+public enum CertificateEncoding: Int32, Sendable {
     case unknown = 0
     case custom = 0x01
     case ber = 0x02

--- a/Sources/Haversack/Queries/CertificateQuery.swift
+++ b/Sources/Haversack/Queries/CertificateQuery.swift
@@ -7,24 +7,7 @@ import Foundation
 ///
 /// Successful searches produce ``CertificateEntity`` objects.
 public struct CertificateQuery {
-    private let queryLock = NSLock()
-    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
-    public var query: SecurityFrameworkQuery {
-        @storageRestrictions(initializes: _query)
-        init {
-            _query = newValue
-        }
-        get {
-            queryLock.withLock {
-                _query
-            }
-        }
-        set {
-            queryLock.withLock {
-                _query = newValue
-            }
-        }
-    }
+    @NSLocked public var query: SecurityFrameworkQuery
 
     /// Create an ``CertificateQuery`` instance
     /// - Parameter label: The keychain label of the item.  Uses `kSecAttrLabel`.

--- a/Sources/Haversack/Queries/GenericPasswordQuery.swift
+++ b/Sources/Haversack/Queries/GenericPasswordQuery.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -7,7 +7,24 @@ import Foundation
 ///
 /// Successful searches produce ``GenericPasswordEntity`` objects.
 public struct GenericPasswordQuery {
-    public var query: SecurityFrameworkQuery
+    private let queryLock = NSLock()
+    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
+    public var query: SecurityFrameworkQuery {
+        @storageRestrictions(initializes: _query)
+        init {
+            _query = newValue
+        }
+        get {
+            queryLock.withLock {
+                _query
+            }
+        }
+        set {
+            queryLock.withLock {
+                _query = newValue
+            }
+        }
+    }
 
     /// Create a GenericPasswordQuery
     /// - Parameter service: The name of the service associated with the password

--- a/Sources/Haversack/Queries/GenericPasswordQuery.swift
+++ b/Sources/Haversack/Queries/GenericPasswordQuery.swift
@@ -7,24 +7,7 @@ import Foundation
 ///
 /// Successful searches produce ``GenericPasswordEntity`` objects.
 public struct GenericPasswordQuery {
-    private let queryLock = NSLock()
-    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
-    public var query: SecurityFrameworkQuery {
-        @storageRestrictions(initializes: _query)
-        init {
-            _query = newValue
-        }
-        get {
-            queryLock.withLock {
-                _query
-            }
-        }
-        set {
-            queryLock.withLock {
-                _query = newValue
-            }
-        }
-    }
+    @NSLocked public var query: SecurityFrameworkQuery
 
     /// Create a GenericPasswordQuery
     /// - Parameter service: The name of the service associated with the password

--- a/Sources/Haversack/Queries/IdentityQuery.swift
+++ b/Sources/Haversack/Queries/IdentityQuery.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import OrderedCollections
@@ -9,7 +9,24 @@ import OrderedCollections
 /// An identity is a certificate plus a private key.
 /// Successful searches produce ``IdentityEntity`` objects.
 public struct IdentityQuery {
-    public var query: SecurityFrameworkQuery
+    private let queryLock = NSLock()
+    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
+    public var query: SecurityFrameworkQuery {
+        @storageRestrictions(initializes: _query)
+        init {
+            _query = newValue
+        }
+        get {
+            queryLock.withLock {
+                _query
+            }
+        }
+        set {
+            queryLock.withLock {
+                _query = newValue
+            }
+        }
+    }
 
     /// Create an ``IdentityQuery`` instance
     /// - Parameter label: The keychain label of the item.  Uses `kSecAttrLabel`.

--- a/Sources/Haversack/Queries/IdentityQuery.swift
+++ b/Sources/Haversack/Queries/IdentityQuery.swift
@@ -9,24 +9,7 @@ import OrderedCollections
 /// An identity is a certificate plus a private key.
 /// Successful searches produce ``IdentityEntity`` objects.
 public struct IdentityQuery {
-    private let queryLock = NSLock()
-    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
-    public var query: SecurityFrameworkQuery {
-        @storageRestrictions(initializes: _query)
-        init {
-            _query = newValue
-        }
-        get {
-            queryLock.withLock {
-                _query
-            }
-        }
-        set {
-            queryLock.withLock {
-                _query = newValue
-            }
-        }
-    }
+    @NSLocked public var query: SecurityFrameworkQuery
 
     /// Create an ``IdentityQuery`` instance
     /// - Parameter label: The keychain label of the item.  Uses `kSecAttrLabel`.

--- a/Sources/Haversack/Queries/InternetPasswordQuery.swift
+++ b/Sources/Haversack/Queries/InternetPasswordQuery.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -7,7 +7,24 @@ import Foundation
 ///
 /// Successful searches produce ``InternetPasswordEntity`` objects.
 public struct InternetPasswordQuery {
-    public var query: SecurityFrameworkQuery
+    private let queryLock = NSLock()
+    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
+    public var query: SecurityFrameworkQuery {
+        @storageRestrictions(initializes: _query)
+        init {
+            _query = newValue
+        }
+        get {
+            queryLock.withLock {
+                _query
+            }
+        }
+        set {
+            queryLock.withLock {
+                _query = newValue
+            }
+        }
+    }
 
     /// Create an ``InternetPasswordQuery``
     /// - Parameter server: The domain name or IP address of a server associated with the password

--- a/Sources/Haversack/Queries/InternetPasswordQuery.swift
+++ b/Sources/Haversack/Queries/InternetPasswordQuery.swift
@@ -7,24 +7,7 @@ import Foundation
 ///
 /// Successful searches produce ``InternetPasswordEntity`` objects.
 public struct InternetPasswordQuery {
-    private let queryLock = NSLock()
-    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
-    public var query: SecurityFrameworkQuery {
-        @storageRestrictions(initializes: _query)
-        init {
-            _query = newValue
-        }
-        get {
-            queryLock.withLock {
-                _query
-            }
-        }
-        set {
-            queryLock.withLock {
-                _query = newValue
-            }
-        }
-    }
+    @NSLocked public var query: SecurityFrameworkQuery
 
     /// Create an ``InternetPasswordQuery``
     /// - Parameter server: The domain name or IP address of a server associated with the password

--- a/Sources/Haversack/Queries/KeyBaseQuerying.swift
+++ b/Sources/Haversack/Queries/KeyBaseQuerying.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -39,7 +39,7 @@ extension KeyBaseQuerying {
 }
 
 /// Encapsulates how cryptographic keys may be used.
-public struct KeyUsagePolicy: OptionSet {
+public struct KeyUsagePolicy: OptionSet, Sendable {
     public let rawValue: Int
 
     public init(rawValue: Int) {

--- a/Sources/Haversack/Queries/KeyQuery.swift
+++ b/Sources/Haversack/Queries/KeyQuery.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -9,7 +9,24 @@ import Foundation
 public struct KeyQuery: KeyBaseQuerying {
     public typealias Entity = KeyEntity
 
-    public var query: SecurityFrameworkQuery
+    private let queryLock = NSLock()
+    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
+    public var query: SecurityFrameworkQuery {
+        @storageRestrictions(initializes: _query)
+        init {
+            _query = newValue
+        }
+        get {
+            queryLock.withLock {
+                _query
+            }
+        }
+        set {
+            queryLock.withLock {
+                _query = newValue
+            }
+        }
+    }
 
     /// Create a ``KeyQuery`` instance
     /// - Parameter label: The keychain label of the item.  Uses `kSecAttrLabel`.
@@ -109,7 +126,7 @@ public struct KeyQuery: KeyBaseQuerying {
 }
 
 /// Encapsulates the cryptographic key's class (public, private, or symmetric).
-public enum KeyClass {
+public enum KeyClass: Sendable {
     /// Represents a private key
     case `private`
     /// Represents a public key
@@ -117,18 +134,18 @@ public enum KeyClass {
     /// Represents a symmetric encryption/decryption key
     case symmetric
 
-    private static let translation: [CFString: KeyClass] = [
-        kSecAttrKeyClassPrivate: .private,
-        kSecAttrKeyClassPublic: .public,
-        kSecAttrKeyClassSymmetric: .symmetric
+    private static let translation: [String: KeyClass] = [
+        kSecAttrKeyClassPrivate as String: .private,
+        kSecAttrKeyClassPublic as String: .public,
+        kSecAttrKeyClassSymmetric as String: .symmetric
     ]
 
     static func make(from securityFrameworkValue: CFString) -> KeyClass? {
-        return translation[securityFrameworkValue]
+        return translation[securityFrameworkValue as String]
     }
 
     func securityFrameworkValue() -> CFString {
-        return Self.translation.first(where: { $1 == self })!.key
+        return Self.translation.first(where: { $1 == self })!.key as CFString
     }
 }
 

--- a/Sources/Haversack/Queries/KeyQuery.swift
+++ b/Sources/Haversack/Queries/KeyQuery.swift
@@ -9,24 +9,7 @@ import Foundation
 public struct KeyQuery: KeyBaseQuerying {
     public typealias Entity = KeyEntity
 
-    private let queryLock = NSLock()
-    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
-    public var query: SecurityFrameworkQuery {
-        @storageRestrictions(initializes: _query)
-        init {
-            _query = newValue
-        }
-        get {
-            queryLock.withLock {
-                _query
-            }
-        }
-        set {
-            queryLock.withLock {
-                _query = newValue
-            }
-        }
-    }
+    @NSLocked public var query: SecurityFrameworkQuery
 
     /// Create a ``KeyQuery`` instance
     /// - Parameter label: The keychain label of the item.  Uses `kSecAttrLabel`.

--- a/Sources/Haversack/Queries/KeychainQueryOptions.swift
+++ b/Sources/Haversack/Queries/KeychainQueryOptions.swift
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
 /// Options for what type of data to return from a keychain query.
-public struct KeychainDataOptions: OptionSet {
+public struct KeychainDataOptions: OptionSet, Sendable {
     public let rawValue: Int
 
     public init(rawValue: Int) {
@@ -30,7 +30,7 @@ public struct KeychainDataOptions: OptionSet {
 }
 
 /// Options for how to compare strings in keychain queries.
-public struct KeychainStringComparisonOptions: OptionSet {
+public struct KeychainStringComparisonOptions: OptionSet, Sendable {
     public let rawValue: Int
 
     public init(rawValue: Int) {

--- a/Sources/Haversack/Queries/KeychainQuerying.swift
+++ b/Sources/Haversack/Queries/KeychainQuerying.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -7,7 +7,7 @@ import Foundation
 public typealias SecurityFrameworkQuery = [String: Any]
 
 /// Base protocol for the fluent interface to search for a keychain item
-public protocol KeychainQuerying {
+public protocol KeychainQuerying: Sendable {
     /// The type of entity that is created when searching the keychain with this query.
     associatedtype Entity: KeychainStorable
 

--- a/Sources/Haversack/Queries/PasswordBaseQuerying.swift
+++ b/Sources/Haversack/Queries/PasswordBaseQuerying.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 

--- a/Sources/Haversack/Security/ItemSecurity.swift
+++ b/Sources/Haversack/Security/ItemSecurity.swift
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
 /// Specify the security of the keychain item
-public struct ItemSecurity {
+public struct ItemSecurity: Sendable {
 
     /// The Haversack standard security for keychain items.
     ///
@@ -12,11 +12,28 @@ public struct ItemSecurity {
     /// The item is not part of any app group or keychain group.
     public static let standard = ItemSecurity().retrievableNoThrow(when: .simple(.unlockedThisDeviceOnly))
 
+    private let queryLock = NSLock()
+    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
     /// The keychain query.  **Do not** manipulate this directly.
     ///
     /// You should not manipulate this directly.  Instead use the fluent methods such as ``containedIn(appGroup:)``
     /// and ``retrievable(when:)`` to build up the query.
-    public var query: SecurityFrameworkQuery
+    public var query: SecurityFrameworkQuery {
+        @storageRestrictions(initializes: _query)
+        init {
+            _query = newValue
+        }
+        get {
+            queryLock.withLock {
+                _query
+            }
+        }
+        set {
+            queryLock.withLock {
+                _query = newValue
+            }
+        }
+    }
 
     /// Construct an empty ``ItemSecurity``
     ///

--- a/Sources/Haversack/Security/ItemSecurity.swift
+++ b/Sources/Haversack/Security/ItemSecurity.swift
@@ -12,28 +12,11 @@ public struct ItemSecurity: Sendable {
     /// The item is not part of any app group or keychain group.
     public static let standard = ItemSecurity().retrievableNoThrow(when: .simple(.unlockedThisDeviceOnly))
 
-    private let queryLock = NSLock()
-    private nonisolated(unsafe) var _query: SecurityFrameworkQuery
     /// The keychain query.  **Do not** manipulate this directly.
     ///
     /// You should not manipulate this directly.  Instead use the fluent methods such as ``containedIn(appGroup:)``
     /// and ``retrievable(when:)`` to build up the query.
-    public var query: SecurityFrameworkQuery {
-        @storageRestrictions(initializes: _query)
-        init {
-            _query = newValue
-        }
-        get {
-            queryLock.withLock {
-                _query
-            }
-        }
-        set {
-            queryLock.withLock {
-                _query = newValue
-            }
-        }
-    }
+    @NSLocked public var query: SecurityFrameworkQuery
 
     /// Construct an empty ``ItemSecurity``
     ///

--- a/Sources/Haversack/Security/KeychainFile.swift
+++ b/Sources/Haversack/Security/KeychainFile.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import os.log
@@ -10,7 +10,7 @@ import os.log
 public typealias FilePath = String
 
 /// A function/block that provides the unencrypted plain `String` password to a keychain file on macOS.
-public typealias KeychainPasswordProvider = (_ keychainPath: FilePath) -> String
+public typealias KeychainPasswordProvider = @Sendable (_ keychainPath: FilePath) -> String
 
 /// Represents a legacy custom keychain file to use with the Security framework.
 ///
@@ -23,7 +23,7 @@ public typealias KeychainPasswordProvider = (_ keychainPath: FilePath) -> String
 /// Opening, creating, or deleting a custom keychain file is logged at `.default` level.
 /// Locking/unlocking the keychain file is logged at the `.info` level.
 /// All errors are logged at the `.error` level.
-public class KeychainFile {
+public final class KeychainFile: Sendable {
     /// The path to the system keychain that contains the globally trusted root CA certificates.
     static let rootCertificatesKeychainPath = "/System/Library/Keychains/SystemRootCertificates.keychain"
 
@@ -59,8 +59,25 @@ public class KeychainFile {
     /// A function that provides the password to the keychain file.
     let passwordProvider: KeychainPasswordProvider?
 
+    private let referenceLock = NSLock()
+    private nonisolated(unsafe) var _reference: SecKeychain?
     /// A reference to the opened keychain.
-    var reference: SecKeychain?
+    var reference: SecKeychain? {
+        @storageRestrictions(initializes: _reference)
+        init {
+            _reference = newValue
+        }
+        get {
+            referenceLock.withLock {
+                _reference
+            }
+        }
+        set {
+            referenceLock.withLock {
+                _reference = newValue
+            }
+        }
+    }
 
     /// Create an object representing a custom keychain file.
     /// - Parameters:

--- a/Sources/Haversack/Security/KeychainItemRetrievability.swift
+++ b/Sources/Haversack/Security/KeychainItemRetrievability.swift
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
 /// A typesafe way to specify when a keychain item is available for use.
-public enum KeychainItemRetrievability: Equatable {
+public enum KeychainItemRetrievability: Equatable, Sendable {
     /// Specify when the keychain item is available
     ///
     /// See [Apple: Restricting Keychain Item Accessibility](https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility)

--- a/Sources/Haversack/Security/RetrievabilityLevel.swift
+++ b/Sources/Haversack/Security/RetrievabilityLevel.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -9,7 +9,7 @@ import Foundation
 /// the accessibility APIs that are used for user experience accommodations.
 /// - Note: This is a wrapper around the `kSecAttrAccessible...` constants.  Haversack does not
 /// support the deprecated "always available" levels because they provide no security.
-public enum RetrievabilityLevel: CaseIterable, Equatable {
+public enum RetrievabilityLevel: CaseIterable, Equatable, Sendable {
     /// Retrievable when the device is unlocked; will synchronize to iCloud Keychain and other devices.
     ///
     /// Recommended for standard user applications without background processing.

--- a/Sources/HaversackCryptoKit/GenericPasswordConvertible+CryptoKit.swift
+++ b/Sources/HaversackCryptoKit/GenericPasswordConvertible+CryptoKit.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import CryptoKit
 import Foundation

--- a/Sources/HaversackCryptoKit/SecKeyConvertible.swift
+++ b/Sources/HaversackCryptoKit/SecKeyConvertible.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import CryptoKit
 import Foundation
@@ -9,7 +9,7 @@ import os.log
 // MARK: - SecKeyConvertible
 
 /// Protocol for CryptoKit key types that can be converted to `SecKey` representations.
-public protocol SecKeyConvertible {
+public protocol SecKeyConvertible: Sendable {
     /// Creates a key from an X9.63 representation.
     init<Bytes>(x963Representation: Bytes) throws where Bytes: ContiguousBytes
 
@@ -41,7 +41,7 @@ public extension KeyEntity {
     /// with the initialized ``KeyEntity``.
     /// - Parameter key: A CryptoKit elliptic key
     /// - Throws: Throws an `NSError` if there is a problem converting to a `SecKey`
-    convenience init<T: SecKeyConvertible>(_ key: T) throws {
+    init<T: SecKeyConvertible>(_ key: T) throws {
         let attributes = [kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
                           kSecAttrKeyClass: kSecAttrKeyClassPrivate] as [String: Any]
         var possibleError: Unmanaged<CFError>?

--- a/Sources/HaversackMock/HaversackEphemeralStrategy+mocking.swift
+++ b/Sources/HaversackMock/HaversackEphemeralStrategy+mocking.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Haversack
 import Security

--- a/Sources/HaversackMock/HaversackEphemeralStrategy.swift
+++ b/Sources/HaversackMock/HaversackEphemeralStrategy.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import Haversack
@@ -7,7 +7,7 @@ import Haversack
 /// A strategy which uses a simple dictionary to import, export, search, store, and delete data instead of hitting an actual keychain.
 ///
 /// The keys of the ``mockData`` dictionary are calculated from the queries that are sent through Haversack.
-open class HaversackEphemeralStrategy: HaversackStrategy {
+open class HaversackEphemeralStrategy: HaversackStrategy, @unchecked Sendable {
     /// The dictionary that is used for storage of keychain items
     ///
     /// Items can be added into or removed from this dictionary manually.

--- a/Sources/HaversackMock/HaversackEphemeralStrategy.swift
+++ b/Sources/HaversackMock/HaversackEphemeralStrategy.swift
@@ -5,8 +5,11 @@ import Foundation
 import Haversack
 
 /// A strategy which uses a simple dictionary to import, export, search, store, and delete data instead of hitting an actual keychain.
-///
+/// 
 /// The keys of the ``mockData`` dictionary are calculated from the queries that are sent through Haversack.
+///
+/// The class conforms to `@unchecked Sendable` in order to support subclassing, but it should only be used serially during
+/// testing and is not inherently thread-safe.
 open class HaversackEphemeralStrategy: HaversackStrategy, @unchecked Sendable {
     /// The dictionary that is used for storage of keychain items
     ///

--- a/Tests/HaversackTests/CertificateIntegrationTests.swift
+++ b/Tests/HaversackTests/CertificateIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/Data+X501NameTests.swift
+++ b/Tests/HaversackTests/Data+X501NameTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import OrderedCollections
 import XCTest

--- a/Tests/HaversackTests/EphemeralStrategyTests.swift
+++ b/Tests/HaversackTests/EphemeralStrategyTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack
@@ -20,7 +20,7 @@ final class EphemeralStrategyTests: XCTestCase {
             .matching(account: "luke")
             .returning(.reference)
 
-        let expectedEntity = InternetPasswordEntity()
+        var expectedEntity = InternetPasswordEntity()
         expectedEntity.protocol = .appleTalk
         try haversack.setSearchFirstMock(where: pwQuery, mockValue: expectedEntity)
 
@@ -39,7 +39,7 @@ final class EphemeralStrategyTests: XCTestCase {
         let pwQuery = GenericPasswordQuery(service: testService)
             .returning(.reference)
 
-        let expectedEntity = GenericPasswordEntity()
+        var expectedEntity = GenericPasswordEntity()
         expectedEntity.service = testService
         try haversack.setSearchFirstMock(where: pwQuery, mockValue: expectedEntity)
 
@@ -74,7 +74,7 @@ final class EphemeralStrategyTests: XCTestCase {
         let pwQuery = GenericPasswordQuery(service: testService)
             .returning(.reference)
 
-        let expectedEntity = GenericPasswordEntity()
+        var expectedEntity = GenericPasswordEntity()
         expectedEntity.service = testService
         try haversack.setSearchFirstMock(where: pwQuery, mockValue: expectedEntity)
 
@@ -94,7 +94,7 @@ final class EphemeralStrategyTests: XCTestCase {
         let pwQuery = GenericPasswordQuery(service: testService)
             .returning(.reference)
 
-        let expectedEntity = GenericPasswordEntity()
+        var expectedEntity = GenericPasswordEntity()
         expectedEntity.service = testService
         try haversack.setSearchMock(where: pwQuery, mockValue: [expectedEntity])
 
@@ -110,7 +110,7 @@ final class EphemeralStrategyTests: XCTestCase {
 
     func testSetSaveMock() throws {
         // Given
-        let mockEntity = GenericPasswordEntity()
+        var mockEntity = GenericPasswordEntity()
         let testService = "unit.test"
         mockEntity.service = testService
 

--- a/Tests/HaversackTests/GenericPasswordConvertibleTests.swift
+++ b/Tests/HaversackTests/GenericPasswordConvertibleTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack
@@ -53,12 +53,12 @@ final class GenericPasswordConvertibleTests: XCTestCase {
         let testInstance = MyTestType(aString: "unit test", anInt: 7)
 
         // when
-        let entity = GenericPasswordEntity(testInstance)
+        var entity = GenericPasswordEntity(testInstance)
         entity.service = "testing"
         let actual = try haversack.save(entity, itemSecurity: .standard, updateExisting: false)
 
         // then
-        XCTAssertIdentical(actual, entity)
+        XCTAssertEqual(actual, entity)
         let insertedData = try XCTUnwrap(strategy.mockData["classgenppdmnakusvcetestv_Data"] as? SecurityFrameworkQuery)
         XCTAssertEqual(insertedData.count, 4)
         XCTAssertEqual(insertedData[kSecClass as String] as? String, kSecClassGenericPassword as String)
@@ -68,7 +68,7 @@ final class GenericPasswordConvertibleTests: XCTestCase {
 
     func testMyTestTypeCanLoad() throws {
         // given
-        let expectedEntity = GenericPasswordEntity()
+        var expectedEntity = GenericPasswordEntity()
         expectedEntity.service = "test_load"
         expectedEntity.passwordData = #"{"aString":"yes we can","anInt":65}"#.data(using: .utf8)
         strategy.mockData["classgenpm_Limitm_Lir_Datasvcetest"] = expectedEntity
@@ -87,7 +87,7 @@ final class GenericPasswordConvertibleTests: XCTestCase {
 
     func testSecondTypeCanLoad() throws {
         // given
-        let expectedEntity = GenericPasswordEntity()
+        var expectedEntity = GenericPasswordEntity()
         expectedEntity.service = "test_load_2"
         expectedEntity.passwordData = "Hello".data(using: .utf8)
         strategy.mockData["classgenpm_Limitm_Lir_Datasvcetest"] = expectedEntity
@@ -104,7 +104,7 @@ final class GenericPasswordConvertibleTests: XCTestCase {
 
     func testAttemptedLoadOfWrongTypeThrows() throws {
         // given
-        let expectedEntity = GenericPasswordEntity()
+        var expectedEntity = GenericPasswordEntity()
         expectedEntity.service = "test_load"
         expectedEntity.passwordData = #"{"aString":"yes we can","anInt":65}"#.data(using: .utf8)
         strategy.mockData["classgenpm_Limitm_Lir_Datasvcetest"] = expectedEntity

--- a/Tests/HaversackTests/GenericPasswordIntegrationTests.swift
+++ b/Tests/HaversackTests/GenericPasswordIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack
@@ -25,7 +25,7 @@ final class GenericPasswordIntegrationTests: XCTestCase {
     func testSaveOverExistingGenericPassword() throws {
         // given
         let customData = try XCTUnwrap("some test".data(using: .utf8))
-        let givenPassword = GenericPasswordEntity()
+        var givenPassword = GenericPasswordEntity()
         givenPassword.customData = customData
         givenPassword.passwordData = "top secret".data(using: .utf8)
         try haversack.save(givenPassword, itemSecurity: .standard, updateExisting: false)
@@ -35,7 +35,7 @@ final class GenericPasswordIntegrationTests: XCTestCase {
         }
 
         // when - we try to overwrite the password with a new value.
-        let newPassword = GenericPasswordEntity()
+        var newPassword = GenericPasswordEntity()
         newPassword.customData = customData
         newPassword.passwordData = "new secret".data(using: .utf8)
         try haversack.save(newPassword, itemSecurity: .standard, updateExisting: true)

--- a/Tests/HaversackTests/HaversackAsyncAwaitTests.swift
+++ b/Tests/HaversackTests/HaversackAsyncAwaitTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import Haversack
@@ -13,7 +13,7 @@ final class HaversackAsyncAwaitTests: XCTestCase {
 
     private let sampleDomain = "example.com"
     private let sampleEntity: InternetPasswordEntity = {
-        let entity = InternetPasswordEntity()
+        var entity = InternetPasswordEntity()
         entity.server = "example.com"
         return entity
     }()

--- a/Tests/HaversackTests/HaversackTests.swift
+++ b/Tests/HaversackTests/HaversackTests.swift
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import Haversack
 import HaversackMock
 import XCTest
 
-final class HaversackTests: XCTestCase {
+final class HaversackTests: XCTestCase, @unchecked Sendable {
     var haversack: Haversack!
     var strategy: HaversackEphemeralStrategy!
 
     private let sampleDomain = "example.com"
     private let sampleEntity: InternetPasswordEntity = {
-        let entity = InternetPasswordEntity()
+        var entity = InternetPasswordEntity()
         entity.server = "example.com"
         return entity
     }()
     private let sampleKey: KeyEntity = {
-        let entity = KeyEntity()
+        var entity = KeyEntity()
         entity.label = "example.com"
         entity.keySizeInBits = 2048
         return entity

--- a/Tests/HaversackTests/HaversackTests.swift
+++ b/Tests/HaversackTests/HaversackTests.swift
@@ -6,7 +6,7 @@ import Haversack
 import HaversackMock
 import XCTest
 
-final class HaversackTests: XCTestCase, @unchecked Sendable {
+final class HaversackTests: XCTestCase {
     var haversack: Haversack!
     var strategy: HaversackEphemeralStrategy!
 
@@ -95,10 +95,10 @@ final class HaversackTests: XCTestCase, @unchecked Sendable {
         let queryFinished = expectation(description: "search finished")
 
         // when
-        haversack.first(where: pwQuery) { (result) in
+        haversack.first(where: pwQuery) { [sampleDomain] (result) in
             // then
             if case .success(let actual) = result {
-                XCTAssertEqual(actual.server, self.sampleDomain)
+                XCTAssertEqual(actual.server, sampleDomain)
             } else if case .failure(let error) = result {
                 XCTFail("Had .failure from first(where:): \(error)")
             }
@@ -152,12 +152,12 @@ final class HaversackTests: XCTestCase, @unchecked Sendable {
         let queryFinished = expectation(description: "search finished")
 
         // when
-        haversack.search(where: keyQuery) { (result) in
+        haversack.search(where: keyQuery) { [sampleDomain] (result) in
             // then
             if case .success(let actual) = result {
                 XCTAssertEqual(actual.count, 1)
                 XCTAssertEqual(actual.first?.keySizeInBits, 2048)
-                XCTAssertEqual(actual.first?.label, self.sampleDomain)
+                XCTAssertEqual(actual.first?.label, sampleDomain)
             } else if case .failure(let error) = result {
                 XCTFail("Had .failure from search(where:): \(error)")
             }
@@ -181,10 +181,10 @@ final class HaversackTests: XCTestCase, @unchecked Sendable {
         let queryFinished = expectation(description: "search finished")
 
         // when
-        haversack.save(sampleEntity, itemSecurity: .standard, updateExisting: true) { (result) in
+        haversack.save(sampleEntity, itemSecurity: .standard, updateExisting: true) { [sampleDomain] (result) in
             // then
             if case .success(let actual) = result {
-                XCTAssertEqual(actual.server, self.sampleDomain)
+                XCTAssertEqual(actual.server, sampleDomain)
             } else if case .failure(let error) = result {
                 XCTFail("Had .failure from save(): \(error)")
             }

--- a/Tests/HaversackTests/IdentityIntegrationTests.swift
+++ b/Tests/HaversackTests/IdentityIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/InternetPasswordIntegrationTests.swift
+++ b/Tests/HaversackTests/InternetPasswordIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack
@@ -31,7 +31,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
         try keychainFile.attemptToOpenOrCreate()
 
         // then
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.authenticationType = .HTTPDigest
         newPassword.account = "Chewbacca"
         newPassword.path = "falcon/holotable"
@@ -45,7 +45,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
 
         XCTAssertNotNil(savedPassword)
 
-        let genericPassword = GenericPasswordEntity()
+        var genericPassword = GenericPasswordEntity()
         genericPassword.account = "Mac Custom File tests"
         genericPassword.service = "General Han Solo"
         genericPassword.comment = "You know, sometimes I amaze myself"
@@ -106,7 +106,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
             .matching(account: "Chewbacca")
             .returning(.attributes)
         let queryFinished = expectation(description: "search finished")
-        var queryResult: InternetPasswordEntity?
+        nonisolated(unsafe) var queryResult: InternetPasswordEntity?
 
         // when
         haversack.first(where: pwQuery, completionQueue: .main) { (result) in
@@ -130,7 +130,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
 
     func testAddInternetPW() throws {
         // given
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.protocol = .HTTPS
         newPassword.server = "testing.example.com"
         newPassword.account = "mine too"
@@ -151,7 +151,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
 
     func testUpdateInternetPWExistingThrows() throws {
         // given
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.protocol = .HTTPS
         newPassword.server = "update.example.com"
         newPassword.account = "mine too"
@@ -166,7 +166,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
         }
 
         // when
-        let attemptToUpdate = InternetPasswordEntity()
+        var attemptToUpdate = InternetPasswordEntity()
         attemptToUpdate.protocol = .HTTPS
         attemptToUpdate.server = "update.example.com"
         attemptToUpdate.account = "mine too"
@@ -180,7 +180,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
 
     func testUpdateInternetPW() throws {
         // given
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.protocol = .HTTPS
         newPassword.server = "update.example.com"
         newPassword.account = "mine too"
@@ -194,7 +194,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
             try? haversack.delete(savedPassword)
         }
 
-        let attemptToUpdate = InternetPasswordEntity()
+        var attemptToUpdate = InternetPasswordEntity()
         attemptToUpdate.protocol = .HTTPS
         attemptToUpdate.server = "update.example.com"
         attemptToUpdate.account = "mine too"
@@ -214,7 +214,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
 
     func testInternetPWMatchLabelFirst() throws {
         // given
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.label = "The test label"
         newPassword.passwordData = "top secret".data(using: .utf8)
         // Use login keychain
@@ -238,7 +238,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
 
     func testInternetPWMatchLabelSearch() throws {
         // given
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.label = "The test label"
         newPassword.passwordData = "top secret".data(using: .utf8)
         // Use login keychain
@@ -263,7 +263,7 @@ final class InternetPasswordIntegrationTests: XCTestCase {
 
     func testInternetPWFirstForDataWorks() throws {
         // given
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.label = "The test label"
         newPassword.passwordData = "top secret".data(using: .utf8)
         // Use login keychain

--- a/Tests/HaversackTests/KeyGenerationConfigTests.swift
+++ b/Tests/HaversackTests/KeyGenerationConfigTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/KeyGenerationIntegrationTests.swift
+++ b/Tests/HaversackTests/KeyGenerationIntegrationTests.swift
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
+@preconcurrency import Security
 import Haversack
 
 #if os(macOS)
@@ -54,7 +55,7 @@ final class KeyGenerationIntegrationTests: XCTestCase {
             .labeled("Async Key")
             .tagged(theTag)
         let keyGenerated = expectation(description: "new key has been generated")
-        var newKey: SecKey?
+        nonisolated(unsafe) var newKey: SecKey?
 
         // when
         haversack.generateKey(fromConfig: keyInfo, itemSecurity: .standard,

--- a/Tests/HaversackTests/KeychainExportConfigTests.swift
+++ b/Tests/HaversackTests/KeychainExportConfigTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 @testable import Haversack

--- a/Tests/HaversackTests/KeychainExportIntegrationTests.swift
+++ b/Tests/HaversackTests/KeychainExportIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/KeychainFileIntegrationTests.swift
+++ b/Tests/HaversackTests/KeychainFileIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 
@@ -22,7 +22,7 @@ final class KeychainFileIntegrationTests: XCTestCase {
         let config = HaversackConfiguration(keychain: keychainFile)
         let haversack = Haversack(configuration: config)
 
-        let newPassword = InternetPasswordEntity()
+        var newPassword = InternetPasswordEntity()
         newPassword.server = "test.example.com"
         newPassword.label = "unit test password"
         newPassword.passwordData = "top secret".data(using: .utf8)

--- a/Tests/HaversackTests/KeychainImportConfigTests.swift
+++ b/Tests/HaversackTests/KeychainImportConfigTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 @testable import Haversack

--- a/Tests/HaversackTests/KeychainImportIntegrationTests.swift
+++ b/Tests/HaversackTests/KeychainImportIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/QueryCertificateTests.swift
+++ b/Tests/HaversackTests/QueryCertificateTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/QueryIdentityTests.swift
+++ b/Tests/HaversackTests/QueryIdentityTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/QueryKeyTests.swift
+++ b/Tests/HaversackTests/QueryKeyTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/QueryPasswordTests.swift
+++ b/Tests/HaversackTests/QueryPasswordTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack

--- a/Tests/HaversackTests/SystemKeychainIntegrationTests.swift
+++ b/Tests/HaversackTests/SystemKeychainIntegrationTests.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import XCTest
 import Haversack
@@ -25,7 +25,7 @@ final class SystemKeychainIntegrationTests: XCTestCase {
     func testSearchSystemKeychainMock() throws {
         // given
         let testService = "system.pw"
-        let expectedEntity = GenericPasswordEntity()
+        var expectedEntity = GenericPasswordEntity()
         expectedEntity.service = testService
         strategy.mockData["classgenpm_Limitm_Lim_SearchListr_Refsvcesyst"] = expectedEntity
 
@@ -42,7 +42,7 @@ final class SystemKeychainIntegrationTests: XCTestCase {
 
     func testSaveToSystemKeychainMock() throws {
         // given
-        let aPassword = GenericPasswordEntity()
+        var aPassword = GenericPasswordEntity()
         aPassword.service = "A password"
         aPassword.passwordData = "super secret".data(using: .utf8)
 

--- a/Tests/HaversackTests/XCTestCase+TestResources.swift
+++ b/Tests/HaversackTests/XCTestCase+TestResources.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright 2023, Jamf
+// Copyright 2026, Jamf
 
 import Foundation
 import XCTest
@@ -10,7 +10,7 @@ extension XCTestCase {
     ///   - named: The full name of the file to load.  For example `TestData.xml`
     ///   - relativeToPath: Filled in automatically by the compiler to find the test file on disk.
     /// - Returns: The URL of the file within the test bundle; or nil if the test file cannot be found.
-    func getURLForTestResource(named: String, relativeToPath: StaticString = #file) -> URL {
+    func getURLForTestResource(named: String, relativeToPath: StaticString = #filePath) -> URL {
         let path = URL(fileURLWithPath: "\(relativeToPath)")
         let testURL = path.deletingLastPathComponent().appendingPathComponent("TestResources").appendingPathComponent(named)
         // Causes a wait of 0.002 seconds; why this is important I don't know.


### PR DESCRIPTION
Updates to allow building with Swift 6 and updating the minimum Swift version to 5.10 in order to use `nonisolated(unsafe)` when necessary. Proposing marking as version `1.4.0` as that seemed to be the next logical step in the CHANGELOG. Specifically this PR focused on surgical updates for Swift 6 compatibility without any changes to API behavior or usage while maintaining compatibility to build with Swift 5. In order to maintain Swift 5 compatibility certain Swift 6 features were avoided (i.e. `sending`, `@isolated(any)`, et al) and the more strict `Sendable` conformance is used. The most major change is that the `*Entity` types were changed from classes to structs since alternative options would introduce even more complex changes (e.g mutex, actor, etc) that are required for `Sendable` conformance in reference types. Due to this change there may be cases in existing code that use this package that will need to be updated, specifically since the mentioned types are no longer classes their mutability is determined by their declaration (now must use `var` instead of `let` to mutate the instance).

```swift
    let myHaversack = Haversack()

    // updating to this version of the package will now require this declaration change to use `var` instead of `let`
    var newPassword = InternetPasswordEntity()

    newPassword.protocol = .HTTPS
    newPassword.server = "test.example.com"
    newPassword.account = "mine"
    newPassword.passwordData = "top secret".data(using: .utf8)
    let savedPassword = try myHaversack.save(newPassword, itemSecurity: .standard, updateExisting: true)
```

This seems like a pretty minor inconvenience, but could also be considered a breaking change since it introduces potential build failures. To avoid breaking any code that automatically updates to this version the proposed version could be updated to `2.0.0` for a major release following SemVer.

There are a few places where `NSLock` is used to protect mutable state, since the minimum version supported is still < macOS 13 `OSAllocatedUnfairLock` is not available, but it could be used instead in a future version when the minimum supported OS versions are updated.

The only significant changes to unit tests were changing the declaration of `*Entity` types to be `var` for mutability, the rest of the API is essentially unchanged.

### API and Type System Changes

* Converted entity types (`CertificateEntity`, `GenericPasswordEntity`, `InternetPasswordEntity`, `IdentityEntity`, `KeyEntity`) from classes to structs for improved value semantics and thread safety. ([[1]](diffhunk://#diff-b8599f5d62b671e8cec4684df32dbeea07cd9948d87199107a6eb38f13d543fcL2-R8), [[2]](diffhunk://#diff-23104f7fea6dcd5590119904d552e56c67a2c19bb8fc6ab1ae2e58c8ac5692d0L2-R82), [[3]](diffhunk://#diff-deaeba94417438ffb24df72e4288c735dbce919ccaaf65fe08c996a8d49c7afeL2-R8), [[4]](diffhunk://#diff-d0065bae46ac5c3b78503a97984a975d3ca6ff5e14487dda1d34739bae897833L2-R82))
* Refactored `PasswordBaseEntity` from a base class to a protocol with default implementations, and updated conforming types accordingly. ([[1]](diffhunk://#diff-23104f7fea6dcd5590119904d552e56c67a2c19bb8fc6ab1ae2e58c8ac5692d0L2-R82), [[2]](diffhunk://#diff-d0065bae46ac5c3b78503a97984a975d3ca6ff5e14487dda1d34739bae897833L2-R82))
* Added `Sendable` conformance to all public types, protocols, and enums, including closure properties and completion handlers, to support Swift concurrency. ([[1]](diffhunk://#diff-23104f7fea6dcd5590119904d552e56c67a2c19bb8fc6ab1ae2e58c8ac5692d0L2-R82), [[2]](diffhunk://#diff-d0065bae46ac5c3b78503a97984a975d3ca6ff5e14487dda1d34739bae897833L20-R93), [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22))
* Made the `KeychainStorable` protocol require `Equatable` conformance. ([CHANGELOG.mdR8-R22](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22))

### Swift Version and Build System

* Updated minimum Swift tools version to 5.10 and added explicit support for Swift 6 in `Package.swift`. ([[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL1-R3), [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL36-R37))
* Updated the project to build with Swift 6, including migration of internal `CFString` dictionary keys to `String` for `Sendable` compatibility. ([CHANGELOG.mdR8-R22](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22))

### Concurrency and Thread Safety

* Updated query and configuration properties to use `NSLock` for thread-safe access. ([CHANGELOG.mdR8-R22](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22))
* Marked all completion handlers and closure properties as `@Sendable`. ([CHANGELOG.mdR8-R22](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22))

### CI/CD and Infrastructure

* Updated GitHub Actions workflow to use newer macOS runners, Xcode simulators, and `actions/checkout` versions for better compatibility and future-proofing. ([.github/workflows/swift.ymlL14-R37](diffhunk://#diff-a15ae93f253d520aafce496a0c3580a16547f5bc50ca16d6dcbfdabf547bd8c5L14-R37))
* Updated copyright years and license headers to 2026 across the codebase. ([[1]](diffhunk://#diff-a15ae93f253d520aafce496a0c3580a16547f5bc50ca16d6dcbfdabf547bd8c5L2-R2), [[2]](diffhunk://#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1fL15-R15), [[3]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3), [[4]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL1-R3), [[5]](diffhunk://#diff-b8599f5d62b671e8cec4684df32dbeea07cd9948d87199107a6eb38f13d543fcL2-R8), [[6]](diffhunk://#diff-713befe0f9110179faf421c6db34364632937ca7d0139f10d7429c890c8bd60dL2-R2), [[7]](diffhunk://#diff-deaeba94417438ffb24df72e4288c735dbce919ccaaf65fe08c996a8d49c7afeL2-R8), [[8]](diffhunk://#diff-d0065bae46ac5c3b78503a97984a975d3ca6ff5e14487dda1d34739bae897833L2-R82))

### Documentation

* Updated `CHANGELOG.md` and `README.md` to reflect the new version, changes, and contributors. ([[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22), [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R148), [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R74))

These changes collectively modernize the codebase for Swift 6, enhance concurrency safety, and improve maintainability and developer experience.